### PR TITLE
pcap_listener.py: Set a timeout for yappcap listener.

### DIFF
--- a/lib/python/pcap_listener.py
+++ b/lib/python/pcap_listener.py
@@ -9,7 +9,7 @@ class PcapFile(abstract.FileDescriptor):
         abstract.FileDescriptor.__init__(self)
 
         p = PcapLive(interface, autosave=dumpfile, snaplen=snaplen,
-                     buffer_size=buffer_size)
+                     buffer_size=buffer_size, timeout=1000)
         p.activate()
         p.blocking = False
 


### PR DESCRIPTION
Per the yappcap documentation:

    timeout (int): The maximum time to wait for a packet. A value of 0 means no
                   timeout. On some platforms this results in waiting until a
                   sufficient number of packets are buffered before returning,
                   therefor it is almost always advisable to set a timeout.
