### PR TITLE
pcap_listener.py: Use immediate mode to avoid packet buffering.

### DIFF
--- a/extras.txt
+++ b/extras.txt
@@ -1,2 +1,2 @@
 https://github.com/asterisk/starpy/archive/refs/heads/1.1.zip
-https://github.com/asterisk/yappcap/archive/refs/heads/python3.zip
+https://github.com/asterisk/yappcap/archive/refs/tags/v0.0.1-py3.zip

--- a/lib/python/pcap_listener.py
+++ b/lib/python/pcap_listener.py
@@ -10,6 +10,7 @@ class PcapFile(abstract.FileDescriptor):
 
         p = PcapLive(interface, autosave=dumpfile, snaplen=snaplen,
                      buffer_size=buffer_size)
+        p.immediate = True
         p.activate()
         p.blocking = False
 
@@ -17,7 +18,7 @@ class PcapFile(abstract.FileDescriptor):
             p.filter = xfilter
 
         self.pcap = p
-        self.fd = p.fileno
+        self.fd = p.selectable_fd
         self.protocol = protocol
         self.protocol.makeConnection(self)
         self.startReading()


### PR DESCRIPTION
This resolves some sporadic test failures where packet capturing was used.