### PR TITLE
tests.yaml: Remove reference to 'incomplete' directory.

### DIFF
--- a/tests/apps/tests.yaml
+++ b/tests/apps/tests.yaml
@@ -6,7 +6,6 @@ tests:
     - dir: 'dial'
     - test: 'originate'
     - dir: 'voicemail'
-    - dir: 'incomplete'
     - dir: 'confbridge'
     - dir: 'page'
     - dir: 'chanspy'


### PR DESCRIPTION
This is a follow-up to 9047ff56e8eb323975db5ef51b8278cb7b9ba6d6.