### PR TITLE
Virtualenv updates

### DIFF
--- a/extras.txt
+++ b/extras.txt
@@ -1,2 +1,2 @@
 https://github.com/asterisk/starpy/archive/refs/heads/1.1.zip
-https://github.com/asterisk/yappcap/archive/refs/tags/v0.0.1-py3.zip
+https://github.com/asterisk/yappcap/archive/refs/tags/v0.0.2-py3.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Cython==0.29.28
 hyperlink==21.0.0
 idna==3.3
 incremental==21.3.0
-lxml==4.8.0
+lxml==4.9.2
 netifaces>=0.10.4
 numpy>=1.19.5
 pycparser==2.21

--- a/setupVenv.sh
+++ b/setupVenv.sh
@@ -16,7 +16,7 @@ then
 	echo "Skipping creation of new environment, configuring"
 	do_pip_setup $VIRTUAL_ENV
 else
-	python3 -m venv .venv
+	python3 -m venv $@ .venv
 	source .venv/bin/activate
 	echo "Activated virtual environment:" $VIRTUAL_ENV
 	if [[ "$VIRTUAL_ENV" != "" ]]


### PR DESCRIPTION
* Updated lxml to 4.9.2 since 4.8.0 will no longer compile
  under latest GCC versions.
* Updated yappcap to v0.0.2-py3 to address Cython version issue.
* setupVenv.sh will now accept parameters which will be passed
  directly to `python -m venv`
