### PR TITLE
codec_builtin: Use multiples of 20 for maximum_ms

### DIFF
--- a/tests/channels/pjsip/sdp_offer_answer/incoming/nominal/single-media-stream/audio/packetization/sipp/uac-ptime-accept.xml
+++ b/tests/channels/pjsip/sdp_offer_answer/incoming/nominal/single-media-stream/audio/packetization/sipp/uac-ptime-accept.xml
@@ -53,7 +53,7 @@
       <ereg regexp="a=ptime:30+..*"
             search_in="body" check_it="true" assign_to="2"/>
       <test assign_to="2" variable="2" compare="equal" value=""/>
-      <ereg regexp="a=maxptime:150+..*"
+      <ereg regexp="a=maxptime:[0-9]+..*"
             search_in="body" check_it="true" assign_to="3"/>
       <test assign_to="3" variable="3" compare="equal" value=""/>
     </action>

--- a/tests/channels/pjsip/sdp_offer_answer/incoming/nominal/single-media-stream/audio/packetization/sipp/uac-ptime-decline-endpoint.xml
+++ b/tests/channels/pjsip/sdp_offer_answer/incoming/nominal/single-media-stream/audio/packetization/sipp/uac-ptime-decline-endpoint.xml
@@ -53,7 +53,7 @@
       <ereg regexp="a=ptime:40+..*"
             search_in="body" check_it="true" assign_to="2"/>
       <test assign_to="2" variable="2" compare="equal" value=""/>
-      <ereg regexp="a=maxptime:150+..*"
+      <ereg regexp="a=maxptime:[0-9]+..*"
             search_in="body" check_it="true" assign_to="3"/>
       <test assign_to="3" variable="3" compare="equal" value=""/>
     </action>

--- a/tests/channels/pjsip/sdp_offer_answer/incoming/nominal/single-media-stream/audio/packetization/sipp/uac-ptime-endpoint.xml
+++ b/tests/channels/pjsip/sdp_offer_answer/incoming/nominal/single-media-stream/audio/packetization/sipp/uac-ptime-endpoint.xml
@@ -52,7 +52,7 @@
       <ereg regexp="a=ptime:40+..*"
             search_in="body" check_it="true" assign_to="2"/>
       <test assign_to="2" variable="2" compare="equal" value=""/>
-      <ereg regexp="a=maxptime:150+..*"
+      <ereg regexp="a=maxptime:[0-9]+..*"
             search_in="body" check_it="true" assign_to="3"/>
       <test assign_to="3" variable="3" compare="equal" value=""/>
     </action>


### PR DESCRIPTION
This change is required to pass change https://github.com/asterisk/asterisk/pull/219

cherry-pick-to: 18
cherry-pick-to: 20
cherry-pick-to: 21