### PR TITLE
codec_builtin: Use multiples of 20 for maximum_ms

### DIFF
--- a/tests/channels/pjsip/sdp_offer_answer/incoming/nominal/single-media-stream/audio/packetization/sipp/uac-ptime-accept.xml
+++ b/tests/channels/pjsip/sdp_offer_answer/incoming/nominal/single-media-stream/audio/packetization/sipp/uac-ptime-accept.xml
@@ -53,7 +53,7 @@
       <ereg regexp="a=ptime:30+..*"
             search_in="body" check_it="true" assign_to="2"/>
       <test assign_to="2" variable="2" compare="equal" value=""/>
-      <ereg regexp="a=maxptime:150+..*"
+      <ereg regexp="a=maxptime:140+..*"
             search_in="body" check_it="true" assign_to="3"/>
       <test assign_to="3" variable="3" compare="equal" value=""/>
     </action>

--- a/tests/channels/pjsip/sdp_offer_answer/incoming/nominal/single-media-stream/audio/packetization/sipp/uac-ptime-decline-endpoint.xml
+++ b/tests/channels/pjsip/sdp_offer_answer/incoming/nominal/single-media-stream/audio/packetization/sipp/uac-ptime-decline-endpoint.xml
@@ -53,7 +53,7 @@
       <ereg regexp="a=ptime:40+..*"
             search_in="body" check_it="true" assign_to="2"/>
       <test assign_to="2" variable="2" compare="equal" value=""/>
-      <ereg regexp="a=maxptime:150+..*"
+      <ereg regexp="a=maxptime:140+..*"
             search_in="body" check_it="true" assign_to="3"/>
       <test assign_to="3" variable="3" compare="equal" value=""/>
     </action>

--- a/tests/channels/pjsip/sdp_offer_answer/incoming/nominal/single-media-stream/audio/packetization/sipp/uac-ptime-endpoint.xml
+++ b/tests/channels/pjsip/sdp_offer_answer/incoming/nominal/single-media-stream/audio/packetization/sipp/uac-ptime-endpoint.xml
@@ -52,7 +52,7 @@
       <ereg regexp="a=ptime:40+..*"
             search_in="body" check_it="true" assign_to="2"/>
       <test assign_to="2" variable="2" compare="equal" value=""/>
-      <ereg regexp="a=maxptime:150+..*"
+      <ereg regexp="a=maxptime:140+..*"
             search_in="body" check_it="true" assign_to="3"/>
       <test assign_to="3" variable="3" compare="equal" value=""/>
     </action>


### PR DESCRIPTION
Allows the test to accept maxptime as a variable value. Some providers require a multiple of 20 for the maxptime or fail to complete calls, e.g. Vivo in Brazil. To increase compatibility, only multiples of 20 are now used.

Resolves: #15

This change is required to pass pull request asterisk/asterisk#219

