### PR TITLE
Replaced SIPp -mp with -min_rtp_port

### DIFF
--- a/lib/python/asterisk/sipp.py
+++ b/lib/python/asterisk/sipp.py
@@ -714,7 +714,7 @@ class SIPpScenario(object):
                 default_args[defarg] = ('%s/sipp/%s' % (
                     self.test_dir, default_args[defarg]))
 
-        if '-mp' not in default_args:
+        if '-min_rtp_port' not in default_args:
             # Current SIPp correctly chooses an available port for audio, but
             # unfortunately it then attempts to bind to the audio port + n for
             # things like rtcp and video without first checking if those other
@@ -724,8 +724,9 @@ class SIPpScenario(object):
             # ourselves, and make sure all associated ports are available.
             #
             # num = 4 = ports for audio rtp/rtcp and video rtp/rtcp
-            default_args['-mp'] = str(get_available_port(
-                default_args.get('-i'), num=4))
+            port = get_available_port(default_args.get('-i'), num=4)
+            default_args['-min_rtp_port'] = str(port)
+            default_args['-max_rtp_port'] = str(port + 3)
 
         for (key, val) in default_args.items():
             sipp_args.extend([key, val])

--- a/tests/channels/pjsip/dialplan_functions/pjsip_channel/test-config.yaml
+++ b/tests/channels/pjsip/dialplan_functions/pjsip_channel/test-config.yaml
@@ -21,7 +21,7 @@ test-object-config:
         -
              scenarios:
                 - { 'key-args': { 'scenario': 'uac-no-hangup.xml', '-p': '5062', '-i': '127.0.0.1',
-                '-s': 'alice', '-rsa': '127.0.0.1:5061', '-s': 'alice', '-mp': '9050'} }
+                '-s': 'alice', '-rsa': '127.0.0.1:5061', '-s': 'alice', '-min_rtp_port': '9050'} }
 
 
 ami-config:

--- a/tests/channels/pjsip/non_negotiated_frame_SSRC_change/test-config.yaml
+++ b/tests/channels/pjsip/non_negotiated_frame_SSRC_change/test-config.yaml
@@ -21,7 +21,7 @@ test-object-config:
         -
             scenarios:
                 - { 'key-args': { 'scenario': 'uas_asterisk.xml', '-i': '127.0.0.1', '-p': '5700'} }
-                - { 'key-args': { 'scenario': 'uac_g719_g711.xml', '-i': '127.0.0.1', '-p': '5061', '-s': '3200000000', '-d': '20000', '-mp': '6000'} }
+                - { 'key-args': { 'scenario': 'uac_g719_g711.xml', '-i': '127.0.0.1', '-p': '5061', '-s': '3200000000', '-d': '20000', '-min_rtp_port': '6000'} }
 
 properties:
     dependencies:

--- a/tests/channels/pjsip/rtp_ptime/non-transcode/run-test
+++ b/tests/channels/pjsip/rtp_ptime/non-transcode/run-test
@@ -28,7 +28,7 @@ SIPP_SCENARIOS = [
         'scenario' : 'uas_asterisk.xml',
         '-i' : '127.0.0.1',
         '-p' : '5700',
-        '-mp' : '6300',
+        '-min_rtp_port' : '6300',
         '-message_file' : sippB_logfile,
         '-error_file' : sippB_errfile,
         '-trace_msg' : '-trace_err',

--- a/tests/channels/pjsip/rtp_ptime/transcode/run-test
+++ b/tests/channels/pjsip/rtp_ptime/transcode/run-test
@@ -28,7 +28,7 @@ SIPP_SCENARIOS = [
         'scenario' : 'uas_asterisk.xml',
         '-i' : '127.0.0.1',
         '-p' : '5700',
-        '-mp' : '6300',
+        '-min_rtp_port' : '6300',
         '-message_file' : sippB_logfile,
         '-error_file' : sippB_errfile,
         '-trace_msg' : '-trace_err',

--- a/tests/codecs/opus/fec/jitterbuffer/adaptive/test-config.yaml
+++ b/tests/codecs/opus/fec/jitterbuffer/adaptive/test-config.yaml
@@ -21,10 +21,10 @@ test-object-config:
     test-iterations:
         -
             scenarios:
-                - { 'key-args': { 'scenario':'invite_recv.xml', '-p':'5062', '-mp':'16002' } }
+                - { 'key-args': { 'scenario':'invite_recv.xml', '-p':'5062', '-min_rtp_port':'16002' } }
                   # Specify the RTP port so the rtp analyzer knows where to
                   # listen for packets. The analyzer defaults to 6001.
-                - { 'key-args': { 'scenario':'invite.xml', '-p':'5061', '-mp':'16001' } }
+                - { 'key-args': { 'scenario':'invite.xml', '-p':'5061', '-min_rtp_port':'16001' } }
 
 rtp-analyzer-config:
     # Expected time difference for ulaw

--- a/tests/codecs/opus/fec/jitterbuffer/fixed/test-config.yaml
+++ b/tests/codecs/opus/fec/jitterbuffer/fixed/test-config.yaml
@@ -21,10 +21,10 @@ test-object-config:
     test-iterations:
         -
             scenarios:
-                - { 'key-args': { 'scenario':'invite_recv.xml', '-p':'5062', '-mp':'16002' } }
+                - { 'key-args': { 'scenario':'invite_recv.xml', '-p':'5062', '-min_rtp_port':'16002' } }
                   # Specify the RTP port so the rtp analyzer knows where to
                   # listen for packets. The analyzer defaults to 6001.
-                - { 'key-args': { 'scenario':'invite.xml', '-p':'5061', '-mp':'16001' } }
+                - { 'key-args': { 'scenario':'invite.xml', '-p':'5061', '-min_rtp_port':'16001' } }
 
 rtp-analyzer-config:
     # Expected time difference for ulaw

--- a/tests/codecs/opus/fec/no_jitterbuffer/test-config.yaml
+++ b/tests/codecs/opus/fec/no_jitterbuffer/test-config.yaml
@@ -21,10 +21,10 @@ test-object-config:
     test-iterations:
         -
             scenarios:
-                - { 'key-args': { 'scenario':'invite_recv.xml', '-p':'5062', '-mp':'16002' } }
+                - { 'key-args': { 'scenario':'invite_recv.xml', '-p':'5062', '-min_rtp_port':'16002' } }
                   # Specify the RTP port so the rtp analyzer knows where to
                   # listen for packets. The analyzer defaults to 6001.
-                - { 'key-args': { 'scenario':'invite.xml', '-p':'5061', '-mp':'16001' } }
+                - { 'key-args': { 'scenario':'invite.xml', '-p':'5061', '-min_rtp_port':'16001' } }
 
 rtp-analyzer-config:
     # Expected time difference for ulaw


### PR DESCRIPTION
SIPp parameter -mp has been replaced with -min_rtp_port in SIPp v3.7.0 (released April 2023).
