### PR TITLE
rest_api: Disable flaky test.

### DIFF
--- a/tests/rest_api/channels/external_media/off-nominal/test-config.yaml
+++ b/tests/rest_api/channels/external_media/off-nominal/test-config.yaml
@@ -1,4 +1,5 @@
 testinfo:
+    skip: 'Unstable - issue 28'
     summary: Test External Media channel failure
     description: |
         Attempts to create an externalMedia channel with unsupported


### PR DESCRIPTION
This test consistently fails on the GitHub CI,
causing every single test run to report failure.
This test is being disabled until such time as
the issue with it is resolved.

Resolves: #28