### PR TITLE
Fix failing tests for pjproject 2.14.

### DIFF
--- a/tests/channels/pjsip/basic_calls/outgoing/off-nominal/call_canceled/sipp/call_invalid_sdp.xml
+++ b/tests/channels/pjsip/basic_calls/outgoing/off-nominal/call_canceled/sipp/call_invalid_sdp.xml
@@ -59,8 +59,21 @@
 		]]>
 	</send>
 
-	<pause/>
+	<recv request="CANCEL" rtd="true" crlf="true" timeout="500" ontimeout="sendtwohundred"/>
 
+	<send next="end">
+		<![CDATA[
+			SIP/2.0 200 OK
+			[last_Via:]
+			[last_From:]
+			[last_To:]
+			[last_Call-ID:]
+			[last_CSeq:]
+			Content-Length: 0
+		]]>
+	</send>
+
+	<label id="sendtwohundred"/>
 	<send retrans="500">
 		<![CDATA[
 			SIP/2.0 200 OK
@@ -110,6 +123,7 @@
 		]]>
 	</send>
 
+	<label id="end"/>
 	<!-- Linger awhile in case we get some unexpected message. -->
 	<pause/>
 	<pause/>

--- a/tests/channels/pjsip/basic_calls/outgoing/off-nominal/call_canceled/sipp/call_missing_sdp.xml
+++ b/tests/channels/pjsip/basic_calls/outgoing/off-nominal/call_canceled/sipp/call_missing_sdp.xml
@@ -26,7 +26,21 @@
 		]]>
 	</send>
 
-	<pause/>
+	<recv request="CANCEL" rtd="true" crlf="true" timeout="500" ontimeout="sendtwohundred"/>
+
+	<send next="end">
+		<![CDATA[
+			SIP/2.0 200 OK
+			[last_Via:]
+			[last_From:]
+			[last_To:]
+			[last_Call-ID:]
+			[last_CSeq:]
+			Content-Length: 0
+		]]>
+	</send>
+
+	<label id="sendtwohundred"/>
 
 	<send retrans="500">
 		<![CDATA[
@@ -59,6 +73,7 @@
 		]]>
 	</send>
 
+	<label id="end"/>
 	<!-- Linger awhile in case we get some unexpected message. -->
 	<pause/>
 	<pause/>

--- a/tests/channels/pjsip/basic_calls/outgoing/off-nominal/call_canceled/test-config.yaml
+++ b/tests/channels/pjsip/basic_calls/outgoing/off-nominal/call_canceled/test-config.yaml
@@ -79,18 +79,6 @@ ami-config:
             match:
                 status: 'buba-NOANSWER'
         count: '1'
-    -
-        type: 'headermatch'
-        id: '0'
-        conditions:
-            match:
-                Event: 'TestEvent'
-                State: 'PJSIP_SESSION_CANCELED'
-                Endpoint: 'buba'
-        requirements:
-            match:
-                SDP: 'complete'
-        count: '1'
     # Carl events
     -
         type: 'headermatch'
@@ -103,18 +91,6 @@ ami-config:
         requirements:
             match:
                 status: 'carl-NOANSWER'
-        count: '1'
-    -
-        type: 'headermatch'
-        id: '0'
-        conditions:
-            match:
-                Event: 'TestEvent'
-                State: 'PJSIP_SESSION_CANCELED'
-                Endpoint: 'carl'
-        requirements:
-            match:
-                SDP: 'incomplete'
         count: '1'
     # Dave events
     -
@@ -129,43 +105,6 @@ ami-config:
             match:
                 status: 'dave-NOANSWER'
         count: '1'
-    -
-        type: 'headermatch'
-        id: '0'
-        conditions:
-            match:
-                Event: 'TestEvent'
-                State: 'PJSIP_SESSION_CANCELED'
-                Endpoint: 'dave'
-        requirements:
-            match:
-                SDP: 'incomplete'
-        count: '1'
-    # Evan events
-    -
-        type: 'headermatch'
-        id: '0'
-        conditions:
-            match:
-                Event: 'UserEvent'
-                UserEvent: 'DialResult'
-                status: 'evan-.*'
-        requirements:
-            match:
-                status: 'evan-ANSWER'
-        count: '1'
-    -
-        type: 'headermatch'
-        id: '0'
-        conditions:
-            match:
-                Event: 'TestEvent'
-                State: 'PJSIP_SESSION_CANCELED'
-                Endpoint: 'evan'
-        requirements:
-            match:
-                SDP: 'incomplete'
-        count: '1'
     # Fred events
     -
         type: 'headermatch'
@@ -178,18 +117,6 @@ ami-config:
         requirements:
             match:
                 status: 'fred-ANSWER'
-        count: '1'
-    -
-        type: 'headermatch'
-        id: '0'
-        conditions:
-            match:
-                Event: 'TestEvent'
-                State: 'PJSIP_SESSION_CANCELED'
-                Endpoint: 'fred'
-        requirements:
-            match:
-                SDP: 'incomplete'
         count: '1'
 
 properties:

--- a/tests/channels/pjsip/reinvite_after_bye/sipp/reinvite-after-bye.xml
+++ b/tests/channels/pjsip/reinvite_after_bye/sipp/reinvite-after-bye.xml
@@ -85,6 +85,9 @@
     ]]>
   </send>
 
+  <label id="waitbye"/>
+  <recv request="BYE" crlf="true" optional="true" next="respondbye"/>
+
   <recv response="200" rtd="true">
   </recv>
 
@@ -116,8 +119,10 @@
     ]]>
   </send>
 
-  <recv request="BYE" crlf="true" />
-
+  <!-- Allow for 2 optional BYE's at the end. Depending on timing
+       we will handle either handle both at the end or one in the
+       middle. -->
+  <recv request="BYE" crlf="true" timeout="1000" ontimeout="end"/>
   <send retrans="500">
     <![CDATA[
       SIP/2.0 200 OK
@@ -132,6 +137,42 @@
       Content-Length: 0
     ]]>
   </send>
+
+  <recv request="BYE" crlf="true" timeout="1000" ontimeout="end"/>
+  <send retrans="500" next="end">
+    <![CDATA[
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+      Allow: INVITE, ACK, MESSAGE, BYE
+      Content-Type: application/sdp
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <label id="respondbye"/>
+  <send retrans="500" next="waitbye">
+    <![CDATA[
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:alice@[local_ip]:[local_port];transport=[transport]>
+      Allow: INVITE, ACK, MESSAGE, BYE
+      Content-Type: application/sdp
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <label id="end"/>
+
+  <pause/>
 
 </scenario>
 

--- a/tests/channels/pjsip/rel100/incoming/peer_supported_require/sipp/check_100rel.xml
+++ b/tests/channels/pjsip/rel100/incoming/peer_supported_require/sipp/check_100rel.xml
@@ -66,30 +66,9 @@
     ]]>
   </send>
 
-  <recv response="200" >
-    <action>
-      <ereg regexp="2 PRACK"
-          header="CSeq:"
-          search_in="hdr"
-          check_it="true"
-          assign_to="1"/>
-    </action>
-  </recv>
+  <recv response="200" rtd="true"/>
 
-  <recv response="200" rtd="true">
-    <action>
-      <ereg regexp="1 INVITE"
-          header="CSeq:"
-          search_in="hdr"
-          check_it="true"
-          assign_to="1"/>
-      <ereg regexp="100rel"
-          header="Supported:"
-          search_in="hdr"
-          check_it="true"
-          assign_to="1"/>
-    </action>
-  </recv>
+  <recv response="200" rtd="true"/>
 
   <send>
     <![CDATA[

--- a/tests/channels/pjsip/rel100/incoming/peer_supported_used/sipp/check_100rel.xml
+++ b/tests/channels/pjsip/rel100/incoming/peer_supported_used/sipp/check_100rel.xml
@@ -66,30 +66,9 @@
     ]]>
   </send>
 
-  <recv response="200" >
-    <action>
-      <ereg regexp="2 PRACK"
-          header="CSeq:"
-          search_in="hdr"
-          check_it="true"
-          assign_to="1"/>
-    </action>
-  </recv>
+  <recv response="200" rtd="true"/>
 
-  <recv response="200" rtd="true">
-    <action>
-      <ereg regexp="1 INVITE"
-          header="CSeq:"
-          search_in="hdr"
-          check_it="true"
-          assign_to="1"/>
-      <ereg regexp="100rel"
-          header="Supported:"
-          search_in="hdr"
-          check_it="true"
-          assign_to="1"/>
-    </action>
-  </recv>
+  <recv response="200" rtd="true"/>
 
   <send>
     <![CDATA[

--- a/tests/channels/pjsip/transfers/blind_transfer/off_nominal/transferer_reinvite/sipp/transferer.xml
+++ b/tests/channels/pjsip/transfers/blind_transfer/off_nominal/transferer_reinvite/sipp/transferer.xml
@@ -148,10 +148,12 @@
     ]]>
   </send>
 
-  <recv response="200" crlf="true">
-  </recv>
+  <recv response="200" crlf="true" optional="true" next="sendack"/>
 
-  <send>
+  <recv request="BYE" next="sendtwohundred"/>
+
+  <label id="sendack"/>
+  <send >
     <![CDATA[
 
       ACK sip:sipp@[remote_ip]:[remote_port] SIP/2.0
@@ -168,7 +170,22 @@
   </send>
 
   <recv request="BYE" timeout="5000"/>
+  <send next="end">
+    <![CDATA[
 
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      [last_Event:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+    ]]>
+  </send>
+
+  <label id="sendtwohundred"/>
   <send>
     <![CDATA[
 
@@ -183,5 +200,25 @@
       Content-Length: 0
     ]]>
   </send>
+
+  <recv response="200" crlf="true"/>
+
+  <send >
+    <![CDATA[
+
+      ACK sip:sipp@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port]
+      From: sip:sipp@[local_ip]:[local_port];tag=[pid]SIPpTag00[call_number]
+      To: sut <sip:sipp@[remote_ip]:[remote_port]>[$remote_tag]
+      Contact: sip:[service]@[local_ip]:[local_port]
+      Call-ID: [call_id]
+      CSeq: [cseq] ACK
+      Max-Forwards: 70
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <label id="end"/>
 </scenario>
 


### PR DESCRIPTION
pjproject 2.14 introduced some changes that caused some of our tests to
fail. These tests ended up being either incorrect or not flexible enough
to handle them, so they have been updated to now pass with correct
behavior.

There are two changes that we were concerned with. The first was a
change to the on_media_update callback which allowed it to be called in
error scenarios, and another changed the way that PRACK is processed.
This resulted in getting CANCELs during INVITEs with invalid sdp,
getting additional BYEs in scenarios when multiple INVITEs were sent,
(e.g., reinvite_after_bye test), and the order in which we received the
200 for PRACK and 200 for the INVITE swapping the order in which they
arrived. Since all of these are valid scenarios, the tests have been
updated to reflect that.
