### PR TITLE
Disable pjsip/transfers/blind_transfer/no_target_in_refer

### DIFF
--- a/tests/channels/pjsip/transfers/blind_transfer/no_target_in_refer/test-config.yaml
+++ b/tests/channels/pjsip/transfers/blind_transfer/no_target_in_refer/test-config.yaml
@@ -1,4 +1,5 @@
 testinfo:
+    skip: 'Unstable - issue #31'
     summary: "Ensure that when a REFER without a user is received we transfer to s extension"
     description: |
         'Asterisk originates a call to a Local channel that runs Echo. The other half of


### PR DESCRIPTION
The test keeps failing.  Disable until we can research.

Reference: #31
