### PR TITLE
config.py: Properly escape regex pattern in is_blank_line

### DIFF
--- a/lib/python/asterisk/config.py
+++ b/lib/python/asterisk/config.py
@@ -24,7 +24,7 @@ LOGGER = logging.getLogger(__name__)
 
 def is_blank_line(line):
     """Is this a blank line?"""
-    return re.match("\s*(?:;.*)?$", line) is not None
+    return re.match("\\s*(?:;.*)?$", line) is not None
 
 
 class Category(object):


### PR DESCRIPTION
Python 3.12 warns that regex sequences embedded in strings,
like `"\s*"`, need to be double-escaped: `"\\s*"`

Resolves: #36
