### PR TITLE
More regex and requirements fixes

### DIFF
--- a/lib/python/asterisk/config.py
+++ b/lib/python/asterisk/config.py
@@ -40,10 +40,10 @@ class Category(object):
         self.name = name
         self.template = template
         self.varval_re = re.compile("""
-            \s*                                # Leading whitespace
-            (?P<name>[\w|,\.-]+)               # Option name
-            \s*=>?\s*                          # Separator, = or =>
-            (?P<value>[\w\s=_()/@|,'"\.<>:-]*) # Option value (can be zero-length)
+            \\s*                                # Leading whitespace
+            (?P<name>[\\w|,\\.-]+)               # Option name
+            \\s*=>?\\s*                          # Separator, = or =>
+            (?P<value>[\\w\\s=_()/@|,'"\\.<>:-]*) # Option value (can be zero-length)
             (?:;.*)?$                          # Optional comment before end of line
             """, re.VERBOSE)
 
@@ -71,10 +71,10 @@ class ConfigFile(object):
         """
         self.categories = []
         self.category_re = re.compile("""
-            \s*                        # Leading Whitespace
-            \[(?P<name>[\w,\.-]+)\]    # Category name in square brackets
-            (?:\((?P<template>[!])\))? # Optionally marked as a template
-            \s*(?:;.*)?$               # trailing whitespace or a comment
+            \\s*                        # Leading Whitespace
+            \\[(?P<name>[\\w,\\.-]+)\\]    # Category name in square brackets
+            (?:\\((?P<template>[!])\\))? # Optionally marked as a template
+            \\s*(?:;.*)?$               # trailing whitespace or a comment
             """, re.VERBOSE)
 
         if config_str is None:

--- a/lib/python/asterisk/opensslversion.py
+++ b/lib/python/asterisk/opensslversion.py
@@ -69,7 +69,7 @@ class OpenSSLVersion:
         """Parse the version string"""
         vv = 0
         if version_str is not None:
-            parts = re.split("(\d+)[.](\d+)[.](\d+)([a-z]+)?(?:-(.+))?", version_str)
+            parts = re.split("(\\d+)[.](\\d+)[.](\\d+)([a-z]+)?(?:-(.+))?", version_str)
             if parts[1]:
                 vv += int(parts[1]) << 28
             if parts[2]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ cffi==1.15.0
 charset-normalizer==2.0.12
 constantly==15.1.0
 construct==2.10.68
-cryptography==37.0.2
 Cython==0.29.30
 hyperlink==21.0.0
 idna==3.3
@@ -15,10 +14,12 @@ lxml==5.1.0
 netifaces>=0.10.4
 numpy>=1.19.5
 pycparser==2.21
+pyOpenSSL==24.0.0
 PyYAML==6.0.1
 PyXB-X==1.2.6.1
 rawsocket==0.2
 requests==2.27.1
+service_identity==24.1.0
 six==1.16.0
 Twisted==22.4.0
 txaio==22.2.1


### PR DESCRIPTION
Fixed a few more regex escaping issues in config.py and in
opensslversion.py.

Replaced cryptography with pyopenssl in requirements.txt because
cryptography doesn't include the OpenSSL module which we use
to get the openssl version.  Tests that had "openssl" as a prereq
have not been running because of this.

Resolves: #40
