### PR TITLE
pjsip/diversion:  Add debugging options

### DIFF
--- a/tests/channels/pjsip/diversion/diversion_basic/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/diversion/diversion_basic/configs/ast1/pjsip.conf
@@ -3,10 +3,14 @@ type=system
 timer_t1=100
 timer_b=6400
 
+[global]
+type=global
+debug=yes
+
 [local]
 type=transport
 protocol=udp
-bind=0.0.0.0
+bind=127.0.0.1
 
 [user1-aors]
 type=aor

--- a/tests/channels/pjsip/diversion/diversion_basic_drop_options/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/diversion/diversion_basic_drop_options/configs/ast1/pjsip.conf
@@ -3,10 +3,15 @@ type=system
 timer_t1=100
 timer_b=6400
 
+[global]
+type=global
+debug=yes
+ignore_uri_user_options=yes
+
 [local]
 type=transport
 protocol=udp
-bind=0.0.0.0
+bind=127.0.0.1
 
 [user1-aors]
 type=aor
@@ -44,6 +49,3 @@ direct_media=no
 disallow=all
 allow=ulaw
 
-[global]
-type=global
-ignore_uri_user_options=yes

--- a/tests/channels/pjsip/diversion/diversion_caller_id/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/diversion/diversion_caller_id/configs/ast1/pjsip.conf
@@ -3,10 +3,14 @@ type=system
 timer_t1=100
 timer_b=6400
 
+[global]
+type=global
+debug=yes
+
 [local]
 type=transport
 protocol=udp
-bind=0.0.0.0
+bind=127.0.0.1
 
 [user1-aors]
 type=aor

--- a/tests/channels/pjsip/diversion/diversion_request/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/diversion/diversion_request/configs/ast1/pjsip.conf
@@ -3,10 +3,14 @@ type=system
 timer_t1=100
 timer_b=6400
 
+[global]
+type=global
+debug=yes
+
 [local]
 type=transport
 protocol=udp
-bind=0.0.0.0
+bind=127.0.0.1
 
 [user1-aors]
 type=aor

--- a/tests/channels/pjsip/diversion/diversion_request_drop_options/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/diversion/diversion_request_drop_options/configs/ast1/pjsip.conf
@@ -3,10 +3,15 @@ type=system
 timer_t1=100
 timer_b=6400
 
+[global]
+type=global
+debug=yes
+ignore_uri_user_options=yes
+
 [local]
 type=transport
 protocol=udp
-bind=0.0.0.0
+bind=127.0.0.1
 
 [user1-aors]
 type=aor
@@ -43,7 +48,3 @@ aors=user3-aors
 direct_media=no
 disallow=all
 allow=ulaw
-
-[global]
-type=global
-ignore_uri_user_options=yes

--- a/tests/channels/pjsip/diversion/diversion_response/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/diversion/diversion_response/configs/ast1/pjsip.conf
@@ -3,10 +3,14 @@ type=system
 timer_t1=100
 timer_b=6400
 
+[global]
+type=global
+debug=yes
+
 [local]
 type=transport
 protocol=udp
-bind=0.0.0.0
+bind=127.0.0.1
 
 [user1-aors]
 type=aor

--- a/tests/channels/pjsip/diversion/diversion_response_181/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/diversion/diversion_response_181/configs/ast1/pjsip.conf
@@ -3,10 +3,14 @@ type=system
 timer_t1=100
 timer_b=6400
 
+[global]
+type=global
+debug=yes
+
 [local]
 type=transport
 protocol=udp
-bind=0.0.0.0
+bind=127.0.0.1
 
 [user1-aors]
 type=aor

--- a/tests/channels/pjsip/diversion/diversion_response_drop_options/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/diversion/diversion_response_drop_options/configs/ast1/pjsip.conf
@@ -3,10 +3,15 @@ type=system
 timer_t1=100
 timer_b=6400
 
+[global]
+type=global
+debug=yes
+ignore_uri_user_options=yes
+
 [local]
 type=transport
 protocol=udp
-bind=0.0.0.0
+bind=127.0.0.1
 
 [user1-aors]
 type=aor
@@ -43,7 +48,3 @@ aors=user3-aors
 direct_media=no
 disallow=all
 allow=ulaw
-
-[global]
-type=global
-ignore_uri_user_options=yes

--- a/tests/channels/pjsip/diversion/history_info_request/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/diversion/history_info_request/configs/ast1/pjsip.conf
@@ -3,10 +3,14 @@ type=system
 timer_t1=100
 timer_b=6400
 
+[global]
+type=global
+debug=yes
+
 [local]
 type=transport
 protocol=udp
-bind=0.0.0.0
+bind=127.0.0.1
 
 [user1-aors]
 type=aor

--- a/tests/channels/pjsip/diversion/history_info_response_181/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/diversion/history_info_response_181/configs/ast1/pjsip.conf
@@ -3,10 +3,14 @@ type=system
 timer_t1=100
 timer_b=6400
 
+[global]
+type=global
+debug=yes
+
 [local]
 type=transport
 protocol=udp
-bind=0.0.0.0
+bind=127.0.0.1
 
 [user1-aors]
 type=aor

--- a/tests/channels/pjsip/diversion/no_diversion_response_181/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/diversion/no_diversion_response_181/configs/ast1/pjsip.conf
@@ -3,10 +3,14 @@ type=system
 timer_t1=100
 timer_b=6400
 
+[global]
+type=global
+debug=yes
+
 [local]
 type=transport
 protocol=udp
-bind=0.0.0.0
+bind=127.0.0.1
 
 [user1-aors]
 type=aor


### PR DESCRIPTION
Enable debug to get packet captures
Bind to 127.0.0.1 instead of 0.0.0.0
