### PR TITLE
app_dial: Add tests for progress dial time.

### DIFF
--- a/tests/apps/dial/dial_progress/configs/ast1/extensions.conf
+++ b/tests/apps/dial/dial_progress/configs/ast1/extensions.conf
@@ -1,0 +1,27 @@
+[default]
+exten => s,1,Answer()
+	same => n,Dial(Local/s@noanswer,^2) ; wait up to 2 seconds for early media. We won't get it, so execution should continue
+	same => n,UserEvent(DialProgress,Result: Pass)
+	same => n,Dial(Local/s@earlymedia,3^2) ; we should get early media, so that will "lock" in this call and we'll wait up to 3 seconds, resulting in a normal NOANSWER
+	same => n,ExecIf($["${DIALSTATUS}"="NOANSWER"]?UserEvent(DialProgress,Result: Pass))
+	same => n,Dial(Local/s@answer,3^2) ; call will answer, so should not continue
+	same => n,UserEvent(DialProgress,Result: Fail)
+	same => n,Hangup()
+
+[noanswer]
+exten => s,1,Wait(99)
+	same => n,Hangup()
+
+[earlymedia]
+exten => s,1,Wait(0.5)
+	same => n,Progress()
+	same => n,Wait(2)
+	same => n,Hangup()
+
+[answer]
+exten => s,1,Wait(0.5)
+	same => n,Progress()
+	same => n,Wait(1)
+	same => n,Answer()
+	same => n,Wait(0.5)
+	same => n,Hangup()

--- a/tests/apps/dial/dial_progress/test-config.yaml
+++ b/tests/apps/dial/dial_progress/test-config.yaml
@@ -1,0 +1,57 @@
+testinfo:
+    summary: 'Ensure that Dial progress timer works correctly.'
+    description: |
+        'This tests the Dial application aborts if progress is not received
+        and a progress timeout is specified, and continues otherwise.'
+
+test-modules:
+    test-object:
+        config-section: test-object-config
+        typename: 'test_case.TestCaseModule'
+    modules:
+        -
+            config-section: caller-originator
+            typename: 'pluggable_modules.Originator'
+        -
+            config-section: hangup-monitor
+            typename: 'pluggable_modules.HangupMonitor'
+        -
+            config-section: ami-config
+            typename: 'pluggable_modules.EventActionModule'
+
+test-object-config:
+    connect-ami: True
+
+caller-originator:
+    channel: 'Local/s@default'
+    context: 'nothing'
+    exten: '0'
+    priority: '1'
+    trigger: 'ami_connect'
+
+hangup-monitor:
+    ids: '0'
+
+ami-config:
+    -
+        ami-events:
+            conditions:
+                match:
+                    Event: 'UserEvent'
+                    UserEvent: 'DialProgress'
+            requirements:
+                match:
+                    Result: 'Pass'
+            count: 2
+        stop_test:
+
+properties:
+    tags:
+        - dial
+        - apps
+    dependencies:
+        - python: 'twisted'
+        - python: 'starpy'
+        - asterisk: 'app_dial'
+        - asterisk: 'app_userevent'
+        - asterisk: 'pbx_config'

--- a/tests/apps/dial/tests.yaml
+++ b/tests/apps/dial/tests.yaml
@@ -2,6 +2,7 @@
 tests:
     - test: 'dial_announcements'
     - test: 'dial_answer'
+    - test: 'dial_progress'
     - test: 'dial_busy'
     - test: 'dial_congestion'
     - test: 'dial_hangup'


### PR DESCRIPTION
Add tests to ensure that the progress timeout
for Dial works as intended.