### PR TITLE
pjsip/identify/transport: Disable due to revert of Asterisk change

### DIFF
--- a/tests/channels/pjsip/identify/transport/test-config.yaml
+++ b/tests/channels/pjsip/identify/transport/test-config.yaml
@@ -1,4 +1,7 @@
 testinfo:
+    skip: |
+      See https://github.com/asterisk/asterisk/security/advisories/GHSA-qqxj-v78h-hrf9
+      And the revert of https://github.com/asterisk/asterisk/pull/602
     summary:     'Tests incoming calls identified by header'
     description: |
         This test covers sending calls to an Asterisk instance


### PR DESCRIPTION
Asterisk PR #602 was reverted due to security concerns so this
test must be disabled until that issue is resolved.
