### PR TITLE
pjsip dtmf_sdp: Modify tests for mismatched digits

### DIFF
--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_negotiation_alice_asym/sipp/alice_opus-amr16-ulaw_opus.xml
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_negotiation_alice_asym/sipp/alice_opus-amr16-ulaw_opus.xml
@@ -45,8 +45,10 @@
 		<ereg regexp="RTP/AVP 96" search_in="body" check_it="true" assign_to = "1" />
 		<ereg regexp="a=rtpmap:96 opus/48000/2" search_in="body" check_it="true" assign_to = "2" />
 		<ereg regexp="a=fmtp:96 maxplaybackrate=24000;sprop-maxcapturerate=24000;maxaveragebitrate=96000" search_in="body" check_it="true" assign_to = "3" />
-		<!-- No telephone-events should be in the response -->
-		<ereg regexp="telephone-event" search_in="body" check_it_inverse="true" assign_to = "4" />
+		<ereg regexp="a=rtpmap:101 telephone-event/8000" search_in="body" check_it="true" assign_to = "4" />
+		<ereg regexp="a=fmtp:101 0-16" search_in="body" check_it="true" assign_to = "5" />
+		<!-- Only 8K telephone-events should be in the response -->
+		<ereg regexp="telephone-event/48000" search_in="body" check_it_inverse="true" assign_to = "6" />
 	</action>
 </recv>
 
@@ -87,6 +89,6 @@
 
 <recv response="200" crlf="true"/>
 
-<Reference variables="1,2,3,4"/>
+<Reference variables="1,2,3,4,5,6"/>
 
 </scenario>

--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_negotiation_alice_asym/sipp/alice_opus-ulaw_opus.xml
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_negotiation_alice_asym/sipp/alice_opus-ulaw_opus.xml
@@ -43,8 +43,10 @@
 		<ereg regexp="RTP/AVP 96" search_in="body" check_it="true" assign_to = "1" />
 		<ereg regexp="a=rtpmap:96 opus/48000/2" search_in="body" check_it="true" assign_to = "2" />
 		<ereg regexp="a=fmtp:96 maxplaybackrate=24000;sprop-maxcapturerate=24000;maxaveragebitrate=96000" search_in="body" check_it="true" assign_to = "3" />
-				<!-- No telephone-events should be in the response -->
-		<ereg regexp="telephone-event" search_in="body" check_it_inverse="true" assign_to = "4" />
+		<ereg regexp="a=rtpmap:101 telephone-event/8000" search_in="body" check_it="true" assign_to = "4" />
+		<ereg regexp="a=fmtp:101 0-16" search_in="body" check_it="true" assign_to = "5" />
+		<!-- Only 8K telephone-events should be in the response -->
+		<ereg regexp="telephone-event/48000" search_in="body" check_it_inverse="true" assign_to = "6" />
 	</action>
 </recv>
 
@@ -85,6 +87,6 @@
 
 <recv response="200" crlf="true"/>
 
-<Reference variables="1,2,3,4"/>
+<Reference variables="1,2,3,4,5,6"/>
 
 </scenario>

--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_negotiation_alice_asym/sipp/alice_ulaw-amr16-opus_opus.xml
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_negotiation_alice_asym/sipp/alice_ulaw-amr16-opus_opus.xml
@@ -46,8 +46,10 @@
 		<ereg regexp="RTP/AVP 97" search_in="body" check_it="true" assign_to = "1" />
 		<ereg regexp="a=rtpmap:97 opus/48000/2" search_in="body" check_it="true" assign_to = "2" />
 		<ereg regexp="a=fmtp:97 maxplaybackrate=24000;sprop-maxcapturerate=24000;maxaveragebitrate=96000" search_in="body" check_it="true" assign_to = "3" />
-		<!-- No telephone-events should be in the response -->
-		<ereg regexp="telephone-event" search_in="body" check_it_inverse="true" assign_to = "4" />
+		<ereg regexp="a=rtpmap:101 telephone-event/8000" search_in="body" check_it="true" assign_to = "4" />
+		<ereg regexp="a=fmtp:101 0-16" search_in="body" check_it="true" assign_to = "5" />
+		<!-- Only 8K telephone-events should be in the response -->
+		<ereg regexp="telephone-event/48000" search_in="body" check_it_inverse="true" assign_to = "6" />
 	</action>
 </recv>
 
@@ -88,6 +90,6 @@
 
 <recv response="200" crlf="true"/>
 
-<Reference variables="1,2,3,4"/>
+<Reference variables="1,2,3,4,5,6"/>
 
 </scenario>

--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_negotiation_alice_asym/sipp/alice_ulaw-opus_opus.xml
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_negotiation_alice_asym/sipp/alice_ulaw-opus_opus.xml
@@ -43,8 +43,10 @@
 		<ereg regexp="RTP/AVP 96" search_in="body" check_it="true" assign_to = "1" />
 		<ereg regexp="a=rtpmap:96 opus/48000/2" search_in="body" check_it="true" assign_to = "2" />
 		<ereg regexp="a=fmtp:96 maxplaybackrate=24000;sprop-maxcapturerate=24000;maxaveragebitrate=96000" search_in="body" check_it="true" assign_to = "3" />
-		<!-- No telephone-events should be in the response -->
-		<ereg regexp="telephone-event" search_in="body" check_it_inverse="true" assign_to = "4" />
+		<ereg regexp="a=rtpmap:101 telephone-event/8000" search_in="body" check_it="true" assign_to = "4" />
+		<ereg regexp="a=fmtp:101 0-16" search_in="body" check_it="true" assign_to = "5" />
+		<!-- Only 8K telephone-events should be in the response -->
+		<ereg regexp="telephone-event/48000" search_in="body" check_it_inverse="true" assign_to = "6" />
 	</action>
 </recv>
 
@@ -85,6 +87,6 @@
 
 <recv response="200" crlf="true"/>
 
-<Reference variables="1,2,3,4"/>
+<Reference variables="1,2,3,4,5,6"/>
 
 </scenario>

--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_negotiation_bob/sipp/bob_wants_opus_only.xml
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_negotiation_bob/sipp/bob_wants_opus_only.xml
@@ -4,12 +4,12 @@
 <scenario name="Basic UAS responder">
   <recv request="INVITE" crlf="true">
 	<action>
-		<ereg regexp="RTP/AVP 107 101" search_in="body" check_it="true" assign_to = "1" />
+		<ereg regexp="RTP/AVP 107 101 102" search_in="body" check_it="true" assign_to = "1" />
 		<ereg regexp="a=rtpmap:107 opus/48000/2" search_in="body" check_it="true" assign_to = "2" />
 		<ereg regexp="a=rtpmap:101 telephone-event/48000" search_in="body" check_it="true" assign_to = "3" />
 		<ereg regexp="a=fmtp:101 0-16" search_in="body" check_it="true" assign_to = "4" />
-    <!-- Only 48K telephone-events should be in the response -->
-		<ereg regexp="telephone-event/8000" search_in="body" check_it_inverse="true" assign_to = "5" />
+		<ereg regexp="a=rtpmap:102 telephone-event/8000" search_in="body" check_it="true" assign_to = "5" />
+		<ereg regexp="a=fmtp:102 0-16" search_in="body" check_it="true" assign_to = "6" />
 	</action>
   </recv>
 
@@ -82,7 +82,7 @@
 
   <timewait milliseconds="500"/>
 
-  <Reference variables="1,2,3,4,5"/>
+  <Reference variables="1,2,3,4,5,6"/>
 
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
 


### PR DESCRIPTION
Change tests to accept RFC 4733/2833 digits at 8K on an endpoint not configured
for 8K codecs.

Fixes: #776
