### PR TITLE
tests/apps: Various fixes - cert-18.9-only

### DIFF
--- a/tests/apps/dial/dial_announcements/configs/ast1/extensions.conf
+++ b/tests/apps/dial/dial_announcements/configs/ast1/extensions.conf
@@ -5,21 +5,20 @@ exten => caller,1,Answer(2)
 
 [default-side-b]
 exten => s,1,Answer()
-	same => n,Set(TIMEOUT(absolute)=12)
+	same => n,Set(TIMEOUT(absolute)=6)
 	same => n,BackgroundDetect(silence/10,200,500)
 	same => n,UserEvent(DialAnnouncementCaller,Result: Fail,Reason: No Announcement Heard)
 	same => n,Hangup()
 exten => talk,1,UserEvent(DialAnnouncementCaller,Result: Pass)
+	same => n,Wait(8)
 	same => n,Hangup()
 
 [somebody]
-exten => s,1,Wait(1)
-	same => n,Progress() ; somebody's phone is ringing!
-	same => n,Wait(${RAND(3,6)}) ; How long until he answers? We don't know.
-	same => n,Set(TIMEOUT(absolute)=7)
-	same => n,Answer()
+exten => s,1,Answer()
+	same => n,Set(TIMEOUT(absolute)=6)
 	same => n,BackgroundDetect(silence/10,200,500)
 	same => n,UserEvent(DialAnnouncementCaller,Result: Fail,Reason: No Announcement Heard)
 	same => n,Hangup()
 exten => talk,1,UserEvent(DialAnnouncementCaller,Result: Pass)
+	same => n,Wait(8)
 	same => n,Hangup()

--- a/tests/apps/dial/dial_announcements/test-config.yaml
+++ b/tests/apps/dial/dial_announcements/test-config.yaml
@@ -32,6 +32,7 @@ caller-originator:
 
 hangup-monitor:
     ids: '0'
+    min-calls: 4
 
 ami-config:
     -

--- a/tests/apps/queues/queue_member_forward/test-config.yaml
+++ b/tests/apps/queues/queue_member_forward/test-config.yaml
@@ -53,14 +53,6 @@ ami-config:
             match:
                 Event: 'DialBegin'
                 Channel: 'Local/caller@default-.*'
-                DestChannel: 'Local/I_DONT_EXIST_OMG@default-.*'
-        count: 1
-    -
-        type: 'headermatch'
-        conditions:
-            match:
-                Event: 'DialBegin'
-                Channel: 'Local/caller@default-.*'
                 DestChannel: 'Local/other_place@default-.*'
         count: 1
     -
@@ -70,9 +62,8 @@ ami-config:
                 Event: 'DialEnd'
                 Channel: 'Local/caller@default-.*'
                 DestChannel: 'PJSIP/redirect-invalid-.*'
-                Forward: 'I_DONT_EXIST_OMG'
                 DialStatus: 'CANCEL'
-        count: 1
+        count: '>0'
     -
         type: 'headermatch'
         conditions:
@@ -118,7 +109,7 @@ originator-config:
 
 hangup-config:
     ids: ['0']
-    min_calls: 8
+    min_calls: 6
 
 properties:
     dependencies:

--- a/tests/apps/senddtmf/test-config.yaml
+++ b/tests/apps/senddtmf/test-config.yaml
@@ -1,5 +1,6 @@
 testinfo:
     summary: 'Ensure that Senddtmf no answer option works as expected'
+    skip: 'SendDTMF always fails if you dont tell it to answer the channel. see GitHub #818'
     description: |
         'We expect that a call to senddtmf by default will not be
          answered while calls to senddtmf with the 'a' = answer flag


### PR DESCRIPTION
* apps/senddtmf: Skipped due to asterisk #818

* apps/queues/queue_member_forward: Fixed events and hangup monitor.

* apps/dial/dial_announcements: Removed random wait, added Wait()s
to allow hangups to process and added min-calls: 4.
