### PR TITLE
tests/apps/dial/dial_parallel: Fix 5 tests

### DIFF
--- a/tests/apps/dial/dial_parallel/dial_parallel_answer_cancel/sipp/charlie.xml
+++ b/tests/apps/dial/dial_parallel/dial_parallel_answer_cancel/sipp/charlie.xml
@@ -78,7 +78,24 @@
         crlf="true">
   </recv>
 
-  <pause milliseconds="2000" />
+  <recv request="BYE" timeout="2000" ontimeout="send_bye"/>
+
+  <send next="done">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <label id="send_bye"/>
 
   <send retrans="500">
     <![CDATA[
@@ -100,9 +117,6 @@
   <recv response="200">
   </recv>
 
-  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
-
-  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+  <label id="done"/>
 
 </scenario>
-

--- a/tests/apps/dial/dial_parallel/dial_parallel_answer_cancel/test-config.yaml
+++ b/tests/apps/dial/dial_parallel/dial_parallel_answer_cancel/test-config.yaml
@@ -46,6 +46,15 @@ cdr-config-12:
         lines:
             -
                 accountcode: ''
+                destination: 'echo'
+                dcontext: 'default'
+                callerid: '"" <s>'
+                channel: 'Local/s@default-.{8};1'
+                lastapp: 'AppDial2'
+                disposition: 'ANSWERED'
+                amaflags: 'DOCUMENTATION'
+            -
+                accountcode: ''
                 destination: 's'
                 dcontext: 'default'
                 callerid: '"" <>'

--- a/tests/apps/dial/dial_parallel/dial_parallel_single_busy/sipp/charlie.xml
+++ b/tests/apps/dial/dial_parallel/dial_parallel_single_busy/sipp/charlie.xml
@@ -78,7 +78,24 @@
         crlf="true">
   </recv>
 
-  <pause milliseconds="2000" />
+  <recv request="BYE" timeout="2000" ontimeout="send_bye"/>
+
+  <send next="done">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <label id="send_bye"/>
 
   <send retrans="500">
     <![CDATA[
@@ -100,9 +117,6 @@
   <recv response="200">
   </recv>
 
-  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
-
-  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+  <label id="done"/>
 
 </scenario>
-

--- a/tests/apps/dial/dial_parallel/dial_parallel_single_busy/test-config.yaml
+++ b/tests/apps/dial/dial_parallel/dial_parallel_single_busy/test-config.yaml
@@ -44,6 +44,15 @@ cdr-config-12:
         lines:
             -
                 accountcode: ''
+                destination: 'echo'
+                dcontext: 'default'
+                callerid: '"" <s>'
+                channel: 'Local/s@default-.{8};1'
+                lastapp: 'AppDial2'
+                disposition: 'ANSWERED'
+                amaflags: 'DOCUMENTATION'
+            -
+                accountcode: ''
                 destination: 's'
                 dcontext: 'default'
                 callerid: '"" <>'

--- a/tests/apps/dial/dial_parallel/dial_parallel_single_congestion/sipp/charlie.xml
+++ b/tests/apps/dial/dial_parallel/dial_parallel_single_congestion/sipp/charlie.xml
@@ -78,7 +78,24 @@
         crlf="true">
   </recv>
 
-  <pause milliseconds="2000" />
+  <recv request="BYE" timeout="2000" ontimeout="send_bye"/>
+
+  <send next="done">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <label id="send_bye"/>
 
   <send retrans="500">
     <![CDATA[
@@ -100,9 +117,6 @@
   <recv response="200">
   </recv>
 
-  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
-
-  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+  <label id="done"/>
 
 </scenario>
-

--- a/tests/apps/dial/dial_parallel/dial_parallel_single_congestion/test-config.yaml
+++ b/tests/apps/dial/dial_parallel/dial_parallel_single_congestion/test-config.yaml
@@ -44,6 +44,15 @@ cdr-config-12:
         lines:
             -
                 accountcode: ''
+                destination: 'echo'
+                dcontext: 'default'
+                callerid: '"" <s>'
+                channel: 'Local/s@default-.{8};1'
+                lastapp: 'AppDial2'
+                disposition: 'ANSWERED'
+                amaflags: 'DOCUMENTATION'
+            -
+                accountcode: ''
                 destination: 's'
                 dcontext: 'default'
                 callerid: '"" <>'

--- a/tests/apps/dial/dial_parallel/dial_parallel_single_no_answer/sipp/charlie.xml
+++ b/tests/apps/dial/dial_parallel/dial_parallel_single_no_answer/sipp/charlie.xml
@@ -78,7 +78,24 @@
         crlf="true">
   </recv>
 
-  <pause milliseconds="2000" />
+  <recv request="BYE" timeout="2000" ontimeout="send_bye"/>
+
+  <send next="done">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <label id="send_bye"/>
 
   <send retrans="500">
     <![CDATA[
@@ -100,9 +117,6 @@
   <recv response="200">
   </recv>
 
-  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
-
-  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+  <label id="done"/>
 
 </scenario>
-

--- a/tests/apps/dial/dial_parallel/dial_parallel_single_no_answer/test-config.yaml
+++ b/tests/apps/dial/dial_parallel/dial_parallel_single_no_answer/test-config.yaml
@@ -45,6 +45,15 @@ cdr-config-12:
         lines:
             -
                 accountcode: ''
+                destination: 'echo'
+                dcontext: 'default'
+                callerid: '"" <s>'
+                channel: 'Local/s@default-.{8};1'
+                lastapp: 'AppDial2'
+                disposition: 'ANSWERED'
+                amaflags: 'DOCUMENTATION'
+            -
+                accountcode: ''
                 destination: 's'
                 dcontext: 'default'
                 callerid: '"" <>'

--- a/tests/apps/dial/dial_parallel/dial_parallel_single_unavail/sipp/charlie.xml
+++ b/tests/apps/dial/dial_parallel/dial_parallel_single_unavail/sipp/charlie.xml
@@ -47,7 +47,7 @@
     ]]>
   </send>
 
-  <pause milliseconds="1000" />
+  <pause milliseconds="500" />
 
   <send retrans="500">
     <![CDATA[
@@ -78,9 +78,24 @@
         crlf="true">
   </recv>
 
-  <pause/>
+  <recv request="BYE" timeout="2000" ontimeout="send_bye"/>
 
-  <pause milliseconds="2000" />
+  <send next="done">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <label id="send_bye"/>
 
   <send retrans="500">
     <![CDATA[
@@ -102,9 +117,6 @@
   <recv response="200">
   </recv>
 
-  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
-
-  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+  <label id="done"/>
 
 </scenario>
-

--- a/tests/apps/dial/dial_parallel/dial_parallel_single_unavail/test-config.yaml
+++ b/tests/apps/dial/dial_parallel/dial_parallel_single_unavail/test-config.yaml
@@ -44,6 +44,15 @@ cdr-config-12:
         lines:
             -
                 accountcode: ''
+                destination: 'echo'
+                dcontext: 'default'
+                callerid: '"" <s>'
+                channel: 'Local/s@default-.{8};1'
+                lastapp: 'AppDial2'
+                disposition: 'ANSWERED'
+                amaflags: 'DOCUMENTATION'
+            -
+                accountcode: ''
                 destination: 's'
                 dcontext: 'default'
                 callerid: '"" <>'


### PR DESCRIPTION
All 5 tests had the same issues...

* The charlie.xml sipp scenario was copied from other scenarios where
it was sending a BYE.  These tests cause charlie to receive a BYE
so the scenario was changed to expect it within 2 seconds and
if not received, send it.

* The cdr-config in test-config.yaml was also copied from earlier
scenarios that only had one PJSIP and one Local channel and was
therefore expecting only two CDRs.  These tests have two PJSIP
channels and one Local channel and therefore 3 CDRs so another
entry was added to the cdr-config section.
