### PR TITLE
More apps fixes

### DIFF
--- a/tests/apps/confbridge/sfu/nominal/sipp/video_caller_second.xml
+++ b/tests/apps/confbridge/sfu/nominal/sipp/video_caller_second.xml
@@ -2,6 +2,7 @@
 <!DOCTYPE scenario SYSTEM "sipp.dtd">
 
 <scenario name="INVITE to ConfBridge with SDP in initial INVITE">
+  <pause milliseconds="2000"/>
   <send retrans="500">
     <![CDATA[
 
@@ -98,6 +99,8 @@
         rtd="true"
         crlf="true">
   </recv>
+
+  <pause milliseconds="1000"/>
 
   <send retrans="500">
     <![CDATA[

--- a/tests/apps/confbridge/sfu/nominal/test-config.yaml
+++ b/tests/apps/confbridge/sfu/nominal/test-config.yaml
@@ -14,13 +14,17 @@ test-modules:
 
 test-object-config:
     memcheck-delay-stop: 7
-    fail-on-any: False
+    fail-on-any: True
     test-iterations:
         -
             scenarios:
                 # IPv4 & UDP
-                - { 'key-args': {'scenario': 'video_caller_first.xml', '-i': '127.0.0.1', '-p': '5061', '-s': 'video-caller'} }
-                - { 'key-args': {'scenario': 'video_caller_second.xml', '-i': '127.0.0.1', '-p': '5062', '-d': '5000', '-s': 'video-caller'} }
+                - { 'key-args': {'scenario': 'video_caller_first.xml', '-i': '127.0.0.1',
+                      '-p': '5061', '-s': 'video-caller', '-timeout': '20s'},
+                    'ordered-args': ['-timeout_error']}
+                - { 'key-args': {'scenario': 'video_caller_second.xml', '-i': '127.0.0.1',
+                      '-p': '5062', '-d': '5000', '-s': 'video-caller', '-timeout': '20s'},
+                    'ordered-args': ['-timeout_error']}
 
 properties:
     dependencies:

--- a/tests/funcs/func_evalexten/configs/ast1/extensions.conf
+++ b/tests/funcs/func_evalexten/configs/ast1/extensions.conf
@@ -14,9 +14,11 @@ exten => 0,1,Answer()
 	same => n,Hangup()
 
 [evalexten]
-exten => success,1,UserEvent(EvalExtenSuccess,Result: Pass)
+exten => success,1,Answer()
+	same => n,UserEvent(EvalExtenSuccess,Result: Pass)
 	same => n,Hangup()
-exten => fail,1,UserEvent(EvalExtenFailure,Result: Fail ${RECEIVESFSTATUS} ${digits},Reason: ${digits})
+exten => fail,1,Answer()
+	same => n,UserEvent(EvalExtenFailure,Result: Fail ${RECEIVESFSTATUS} ${digits},Reason: ${digits})
 	same => n,Hangup()
 exten => 1,1,GotoIf($["${EVAL_EXTEN(ee-context-1,${EPOCH},1)}"="4545"]?success,1:fail,1) ; make sure evaluated extension is argument, not current dialplan extension
 exten => 2,1,GotoIf($["${EVAL_EXTEN(ee-context-2,${EPOCH},1)}"=""]?success,1:fail,1) ; non-existent evaluation extension

--- a/tests/funcs/func_evalexten/test-config.yaml
+++ b/tests/funcs/func_evalexten/test-config.yaml
@@ -31,6 +31,7 @@ caller-originator:
 
 hangup-monitor:
     ids: '0'
+    min_calls: 24
 
 ami-config:
     -


### PR DESCRIPTION
* func_evalexten: Answer the calls and set min_calls: 24
* confbridge/sfu/nominal: Added delay before second caller hangs up
  and added timeouts to sipp scenarios.
