### PR TITLE
Disable tests/apps/dial/preserve_top because of frequent failures

### DIFF
--- a/tests/apps/dial/preserve_top/test-config.yaml
+++ b/tests/apps/dial/preserve_top/test-config.yaml
@@ -2,6 +2,7 @@
 testinfo:
     summary: |
         'Test the Dial option "j" which preserver the initial topology of the caller.'
+    skip: 'The middle sipp scenario fails often.  See https://github.com/asterisk/testsuite/issues/60'
     description: |
         'Alice calls Bob whose 200 SDP answer contains an audio stream and a
         video stream which is set to recvonly. Bob hangs up and then the Dial


### PR DESCRIPTION
The middle sipp scenario fails often.
See https://github.com/asterisk/testsuite/issues/60
