### PR TITLE
pjsip/.../nominal/alice_initiated: Use separate addrs and remove ipv6

### DIFF
--- a/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/alice_hangs_up/configs/ast1/extensions.conf
+++ b/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/alice_hangs_up/configs/ast1/extensions.conf
@@ -1,6 +1,4 @@
 [default]
 exten => bob-ipv4-udp,1,Dial(PJSIP/test_call@bob-ipv4-udp)
 exten => bob-ipv4-tcp,1,Dial(PJSIP/test_call@bob-ipv4-tcp)
-exten => bob-ipv6-udp,1,Dial(PJSIP/test_call@bob-ipv6-udp)
-exten => bob-ipv6-tcp,1,Dial(PJSIP/test_call@bob-ipv6-tcp)
 

--- a/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/alice_hangs_up/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/alice_hangs_up/configs/ast1/pjsip.conf
@@ -5,38 +5,20 @@ timer_b=6400
 
 [local-transport-template](!)
 type=transport
-bind=127.0.0.1:5060
-
-[local-transport6-template](!)
-type=transport
-bind=[::1]:5060
+bind=127.0.0.10:5060
 
 [local-transport-udp](local-transport-template)
 protocol=udp
 
-[local-transport-udp6](local-transport6-template)
-protocol=udp
-
 [local-transport-tcp](local-transport-template)
-protocol=tcp
-
-[local-transport-tcp6](local-transport6-template)
 protocol=tcp
 
 [endpoint-template-ipv4](!)
 type=endpoint
 context=default
 allow=!all,ulaw,alaw
-media_address=127.0.0.1
+media_address=127.0.0.10
 direct_media=no
-
-[endpoint-template-ipv6](!)
-type=endpoint
-context=default
-allow=!all,ulaw,alaw
-media_address=[::1]
-direct_media=no
-rtp_ipv6=yes
 
 ;=========== Alice ===========
 ;== IPv4 & UDP ==
@@ -46,14 +28,6 @@ transport=local-transport-udp
 ;== IPv4 & TCP ==
 [alice-ipv4-tcp](endpoint-template-ipv4)
 transport=local-transport-tcp
-
-;== IPv6 & UDP ==
-[alice-ipv6-udp](endpoint-template-ipv6)
-transport=local-transport-udp6
-
-;== IPv6 & TCP ==
-[alice-ipv6-tcp](endpoint-template-ipv6)
-transport=local-transport-tcp6
 ;=============================
 
 ;=========== Bob ===========
@@ -64,7 +38,7 @@ aors=bob-ipv4-udp
 
 [bob-ipv4-udp]
 type=aor
-contact=sip:bob-ipv4-udp@127.0.0.1:5062\;transport=udp
+contact=sip:bob-ipv4-udp@127.0.0.12:5060\;transport=udp
 
 ;== IPv4 & TCP ==
 [bob-ipv4-tcp](endpoint-template-ipv4)
@@ -73,24 +47,6 @@ aors=bob-ipv4-tcp
 
 [bob-ipv4-tcp]
 type=aor
-contact=sip:bob-ipv4-tcp@127.0.0.1:5062\;transport=tcp
-
-;== IPv6 & UDP ==
-[bob-ipv6-udp](endpoint-template-ipv6)
-transport=local-transport-udp6
-aors=bob-ipv6-udp
-
-[bob-ipv6-udp]
-type=aor
-contact=sip:bob-ipv6-udp@[::1]:5062\;transport=udp
-
-;;== IPv6 & TCP ==
-[bob-ipv6-tcp](endpoint-template-ipv6)
-transport=local-transport-tcp6
-aors=bob-ipv6-tcp
-
-[bob-ipv6-tcp]
-type=aor
-contact=sip:bob-ipv6-tcp@[::1]:5062\;transport=tcp
+contact=sip:bob-ipv4-tcp@127.0.0.12:5060\;transport=tcp
 ;===========================
 

--- a/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/alice_hangs_up/configs/ast2/pjsip.conf
+++ b/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/alice_hangs_up/configs/ast2/pjsip.conf
@@ -5,38 +5,20 @@ timer_b=6400
 
 [local-transport-template](!)
 type=transport
-bind=127.0.0.1:5061
-
-[local-transport6-template](!)
-type=transport
-bind=[::1]:5061
+bind=127.0.0.11:5060
 
 [local-transport-udp](local-transport-template)
 protocol=udp
 
-[local-transport-udp6](local-transport6-template)
-protocol=udp
-
 [local-transport-tcp](local-transport-template)
-protocol=tcp
-
-[local-transport-tcp6](local-transport6-template)
 protocol=tcp
 
 [endpoint-template-ipv4](!)
 type=endpoint
 context=default
 allow=!all,ulaw,alaw
-media_address=127.0.0.1
+media_address=127.0.0.11
 direct_media=no
-
-[endpoint-template-ipv6](!)
-type=endpoint
-context=default
-allow=!all,ulaw,alaw
-media_address=[::1]
-direct_media=no
-rtp_ipv6=yes
 
 ;== IPv4 & UDP ==
 [uut-ipv4-udp](endpoint-template-ipv4)
@@ -46,7 +28,7 @@ from_user=alice-ipv4-udp
 
 [uut-ipv4-udp]
 type=aor
-contact=sip:uut-ipv4-udp@127.0.0.1:5060\;transport=udp
+contact=sip:uut-ipv4-udp@127.0.0.10:5060\;transport=udp
 
 ;== IPv4 & TCP ==
 [uut-ipv4-tcp](endpoint-template-ipv4)
@@ -56,28 +38,6 @@ from_user=alice-ipv4-tcp
 
 [uut-ipv4-tcp]
 type=aor
-contact=sip:uut-ipv4-tcp@127.0.0.1:5060\;transport=tcp
-;================
-
-;== IPv6 & UDP ==
-[uut-ipv6-udp](endpoint-template-ipv6)
-transport=local-transport-udp6
-aors=uut-ipv6-udp
-from_user=alice-ipv6-udp
-
-[uut-ipv6-udp]
-type=aor
-contact=sip:uut-ipv6-udp@[::1]:5060\;transport=udp
-;================
-
-;== IPv6 & TCP ==
-[uut-ipv6-tcp](endpoint-template-ipv6)
-transport=local-transport-tcp6
-aors=uut-ipv6-tcp
-from_user=alice-ipv6-tcp
-
-[uut-ipv6-tcp]
-type=aor
-contact=sip:uut-ipv6-tcp@[::1]:5060\;transport=tcp
+contact=sip:uut-ipv4-tcp@127.0.0.10:5060\;transport=tcp
 ;================
 

--- a/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/alice_hangs_up/configs/ast3/pjsip.conf
+++ b/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/alice_hangs_up/configs/ast3/pjsip.conf
@@ -5,48 +5,24 @@ timer_b=6400
 
 [local-transport-template](!)
 type=transport
-bind=127.0.0.1:5062
-
-[local-transport6-template](!)
-type=transport
-bind=[::1]:5062
+bind=127.0.0.12:5060
 
 [local-transport-udp](local-transport-template)
 protocol=udp
 
-[local-transport-udp6](local-transport6-template)
-protocol=udp
-
 [local-transport-tcp](local-transport-template)
-protocol=tcp
-
-[local-transport-tcp6](local-transport6-template)
 protocol=tcp
 
 [endpoint-template-ipv4](!)
 type=endpoint
 context=default
 allow=!all,ulaw,alaw
-media_address=127.0.0.1
+media_address=127.0.0.12
 direct_media=no
-
-[endpoint-template-ipv6](!)
-type=endpoint
-context=default
-allow=!all,ulaw,alaw
-media_address=[::1]
-direct_media=no
-rtp_ipv6=yes
 
 [alice-ipv4-udp](endpoint-template-ipv4)
 transport=local-transport-udp
 
 [alice-ipv4-tcp](endpoint-template-ipv4)
 transport=local-transport-tcp
-
-[alice-ipv6-udp](endpoint-template-ipv6)
-transport=local-transport-udp6
-
-[alice-ipv6-tcp](endpoint-template-ipv6)
-transport=local-transport-tcp6
 

--- a/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/alice_hangs_up/test-config.yaml
+++ b/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/alice_hangs_up/test-config.yaml
@@ -19,12 +19,6 @@ test-modules:
             config-section: originator-config-ipv4-tcp
             typename: 'pluggable_modules.Originator'
         -
-            config-section: originator-config-ipv6-udp
-            typename: 'pluggable_modules.Originator'
-        -
-            config-section: originator-config-ipv6-tcp
-            typename: 'pluggable_modules.Originator'
-        -
             config-section: 'ami-config'
             typename: 'ami.AMIEventModule'
 
@@ -53,26 +47,6 @@ originator-config-ipv4-tcp:
     priority: '1'
     async: 'True'
 
-originator-config-ipv6-udp:
-    trigger: 'ami_connect'
-    ignore-originate-failure: 'no'
-    id: '1'
-    channel: 'PJSIP/bob-ipv6-udp@uut-ipv6-udp'
-    context: 'default'
-    exten: 'start'
-    priority: '1'
-    async: 'True'
-
-originator-config-ipv6-tcp:
-    trigger: 'ami_connect'
-    ignore-originate-failure: 'no'
-    id: '1'
-    channel: 'PJSIP/bob-ipv6-tcp@uut-ipv6-tcp'
-    context: 'default'
-    exten: 'start'
-    priority: '1'
-    async: 'True'
-
 ami-config:
     # Alice events
     -
@@ -85,7 +59,7 @@ ami-config:
         requirements:
             match:
                 result: 'pass'
-        count: '4'
+        count: '2'
     -
         type: 'headermatch'
         id: '1'
@@ -96,7 +70,7 @@ ami-config:
         requirements:
             match:
                 Cause: '16'
-        count: '4'
+        count: '2'
     -
         type: 'headermatch'
         id: '1'
@@ -107,7 +81,7 @@ ami-config:
         requirements:
             match:
                 Cause: '16'
-        count: '4'
+        count: '2'
     # Bob events
     -
         type: 'headermatch'
@@ -119,7 +93,7 @@ ami-config:
         requirements:
             match:
                 result: 'pass'
-        count: '4'
+        count: '2'
     -
         type: 'headermatch'
         id: '2'
@@ -129,7 +103,7 @@ ami-config:
         requirements:
             match:
                 Channel: 'PJSIP/alice-*'
-        count: '4'
+        count: '2'
     -
         type: 'headermatch'
         id: '2'
@@ -140,7 +114,7 @@ ami-config:
         requirements:
             match:
                 Cause: '16'
-        count: '4'
+        count: '2'
 
 properties:
     dependencies:

--- a/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/bob_hangs_up/configs/ast1/extensions.conf
+++ b/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/bob_hangs_up/configs/ast1/extensions.conf
@@ -1,6 +1,4 @@
 [default]
 exten => bob-ipv4-udp,1,Dial(PJSIP/test_call@bob-ipv4-udp)
 exten => bob-ipv4-tcp,1,Dial(PJSIP/test_call@bob-ipv4-tcp)
-exten => bob-ipv6-udp,1,Dial(PJSIP/test_call@bob-ipv6-udp)
-exten => bob-ipv6-tcp,1,Dial(PJSIP/test_call@bob-ipv6-tcp)
 

--- a/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/bob_hangs_up/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/bob_hangs_up/configs/ast1/pjsip.conf
@@ -5,38 +5,20 @@ timer_b=6400
 
 [local-transport-template](!)
 type=transport
-bind=127.0.0.1:5060
-
-[local-transport6-template](!)
-type=transport
-bind=[::1]:5060
+bind=127.0.0.10:5060
 
 [local-transport-udp](local-transport-template)
 protocol=udp
 
-[local-transport-udp6](local-transport6-template)
-protocol=udp
-
 [local-transport-tcp](local-transport-template)
-protocol=tcp
-
-[local-transport-tcp6](local-transport6-template)
 protocol=tcp
 
 [endpoint-template-ipv4](!)
 type=endpoint
 context=default
 allow=!all,ulaw,alaw
-media_address=127.0.0.1
+media_address=127.0.0.10
 direct_media=no
-
-[endpoint-template-ipv6](!)
-type=endpoint
-context=default
-allow=!all,ulaw,alaw
-media_address=[::1]
-direct_media=no
-rtp_ipv6=yes
 
 ;=========== Alice ===========
 ;== IPv4 & UDP ==
@@ -44,12 +26,6 @@ rtp_ipv6=yes
 
 ;== IPv4 & TCP ==
 [alice-ipv4-tcp](endpoint-template-ipv4)
-
-;== IPv6 & UDP ==
-[alice-ipv6-udp](endpoint-template-ipv6)
-
-;== IPv6 & TCP ==
-[alice-ipv6-tcp](endpoint-template-ipv6)
 ;=============================
 
 ;=========== Bob ===========
@@ -59,7 +35,7 @@ aors=bob-ipv4-udp
 
 [bob-ipv4-udp]
 type=aor
-contact=sip:bob-ipv4-udp@127.0.0.1:5062\;transport=udp
+contact=sip:bob-ipv4-udp@127.0.0.12:5060\;transport=udp
 
 ;== IPv4 & TCP ==
 [bob-ipv4-tcp](endpoint-template-ipv4)
@@ -67,22 +43,6 @@ aors=bob-ipv4-tcp
 
 [bob-ipv4-tcp]
 type=aor
-contact=sip:bob-ipv4-tcp@127.0.0.1:5062\;transport=tcp
-
-;== IPv6 & UDP ==
-[bob-ipv6-udp](endpoint-template-ipv6)
-aors=bob-ipv6-udp
-
-[bob-ipv6-udp]
-type=aor
-contact=sip:bob-ipv6-udp@[::1]:5062\;transport=udp
-
-;;== IPv6 & TCP ==
-[bob-ipv6-tcp](endpoint-template-ipv6)
-aors=bob-ipv6-tcp
-
-[bob-ipv6-tcp]
-type=aor
-contact=sip:bob-ipv6-tcp@[::1]:5062\;transport=tcp
+contact=sip:bob-ipv4-tcp@127.0.0.12:5060\;transport=tcp
 ;===========================
 

--- a/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/bob_hangs_up/configs/ast2/pjsip.conf
+++ b/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/bob_hangs_up/configs/ast2/pjsip.conf
@@ -5,38 +5,20 @@ timer_b=6400
 
 [local-transport-template](!)
 type=transport
-bind=127.0.0.1:5061
-
-[local-transport6-template](!)
-type=transport
-bind=[::1]:5061
+bind=127.0.0.11:5060
 
 [local-transport-udp](local-transport-template)
 protocol=udp
 
-[local-transport-udp6](local-transport6-template)
-protocol=udp
-
 [local-transport-tcp](local-transport-template)
-protocol=tcp
-
-[local-transport-tcp6](local-transport6-template)
 protocol=tcp
 
 [endpoint-template-ipv4](!)
 type=endpoint
 context=default
 allow=!all,ulaw,alaw
-media_address=127.0.0.1
+media_address=127.0.0.11
 direct_media=no
-
-[endpoint-template-ipv6](!)
-type=endpoint
-context=default
-allow=!all,ulaw,alaw
-media_address=[::1]
-direct_media=no
-rtp_ipv6=yes
 
 ;== IPv4 & UDP ==
 [uut-ipv4-udp](endpoint-template-ipv4)
@@ -45,7 +27,7 @@ from_user=alice-ipv4-udp
 
 [uut-ipv4-udp]
 type=aor
-contact=sip:uut-ipv4-udp@127.0.0.1:5060\;transport=udp
+contact=sip:uut-ipv4-udp@127.0.0.10:5060\;transport=udp
 
 ;== IPv4 & TCP ==
 [uut-ipv4-tcp](endpoint-template-ipv4)
@@ -54,26 +36,5 @@ from_user=alice-ipv4-tcp
 
 [uut-ipv4-tcp]
 type=aor
-contact=sip:uut-ipv4-tcp@127.0.0.1:5060\;transport=tcp
+contact=sip:uut-ipv4-tcp@127.0.0.10:5060\;transport=tcp
 ;================
-
-;== IPv6 & UDP ==
-[uut-ipv6-udp](endpoint-template-ipv6)
-aors=uut-ipv6-udp
-from_user=alice-ipv6-udp
-
-[uut-ipv6-udp]
-type=aor
-contact=sip:uut-ipv6-udp@[::1]:5060\;transport=udp
-;================
-
-;== IPv6 & TCP ==
-[uut-ipv6-tcp](endpoint-template-ipv6)
-aors=uut-ipv6-tcp
-from_user=alice-ipv6-tcp
-
-[uut-ipv6-tcp]
-type=aor
-contact=sip:uut-ipv6-tcp@[::1]:5060\;transport=tcp
-;================
-

--- a/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/bob_hangs_up/configs/ast3/pjsip.conf
+++ b/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/bob_hangs_up/configs/ast3/pjsip.conf
@@ -5,44 +5,22 @@ timer_b=6400
 
 [local-transport-template](!)
 type=transport
-bind=127.0.0.1:5062
-
-[local-transport6-template](!)
-type=transport
-bind=[::1]:5062
+bind=127.0.0.12:5060
 
 [local-transport-udp](local-transport-template)
 protocol=udp
 
-[local-transport-udp6](local-transport6-template)
-protocol=udp
-
 [local-transport-tcp](local-transport-template)
-protocol=tcp
-
-[local-transport-tcp6](local-transport6-template)
 protocol=tcp
 
 [endpoint-template-ipv4](!)
 type=endpoint
 context=default
 allow=!all,ulaw,alaw
-media_address=127.0.0.1
+media_address=127.0.0.12
 direct_media=no
-
-[endpoint-template-ipv6](!)
-type=endpoint
-context=default
-allow=!all,ulaw,alaw
-media_address=[::1]
-direct_media=no
-rtp_ipv6=yes
 
 [alice-ipv4-udp](endpoint-template-ipv4)
 
 [alice-ipv4-tcp](endpoint-template-ipv4)
-
-[alice-ipv6-udp](endpoint-template-ipv6)
-
-[alice-ipv6-tcp](endpoint-template-ipv6)
 

--- a/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/bob_hangs_up/test-config.yaml
+++ b/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/bob_hangs_up/test-config.yaml
@@ -19,12 +19,6 @@ test-modules:
             config-section: originator-config-ipv4-tcp
             typename: 'pluggable_modules.Originator'
         -
-            config-section: originator-config-ipv6-udp
-            typename: 'pluggable_modules.Originator'
-        -
-            config-section: originator-config-ipv6-tcp
-            typename: 'pluggable_modules.Originator'
-        -
             config-section: 'ami-config'
             typename: 'ami.AMIEventModule'
 
@@ -53,26 +47,6 @@ originator-config-ipv4-tcp:
     priority: '1'
     async: 'True'
 
-originator-config-ipv6-udp:
-    trigger: 'ami_connect'
-    ignore-originate-failure: 'no'
-    id: '1'
-    channel: 'PJSIP/bob-ipv6-udp@uut-ipv6-udp'
-    context: 'default'
-    exten: 'start'
-    priority: '1'
-    async: 'True'
-
-originator-config-ipv6-tcp:
-    trigger: 'ami_connect'
-    ignore-originate-failure: 'no'
-    id: '1'
-    channel: 'PJSIP/bob-ipv6-tcp@uut-ipv6-tcp'
-    context: 'default'
-    exten: 'start'
-    priority: '1'
-    async: 'True'
-
 ami-config:
     # Alice events
     -
@@ -85,7 +59,7 @@ ami-config:
         requirements:
             match:
                 result: 'pass'
-        count: '4'
+        count: '2'
     -
         type: 'headermatch'
         id: '1'
@@ -95,7 +69,7 @@ ami-config:
         requirements:
             match:
                 Channel: 'PJSIP/uut-*'
-        count: '4'
+        count: '2'
     -
         type: 'headermatch'
         id: '1'
@@ -106,7 +80,7 @@ ami-config:
         requirements:
             match:
                 Cause: '16'
-        count: '4'
+        count: '2'
     # Bob events
     -
         type: 'headermatch'
@@ -118,7 +92,7 @@ ami-config:
         requirements:
             match:
                 result: 'pass'
-        count: '4'
+        count: '2'
     -
         type: 'headermatch'
         id: '2'
@@ -129,7 +103,7 @@ ami-config:
         requirements:
             match:
                 Cause: '16'
-        count: '4'
+        count: '2'
     -
         type: 'headermatch'
         id: '2'
@@ -140,7 +114,7 @@ ami-config:
         requirements:
             match:
                 Cause: '16'
-        count: '4'
+        count: '2'
 
 properties:
     dependencies:

--- a/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/requested_capabilities/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/requested_capabilities/configs/ast1/pjsip.conf
@@ -5,7 +5,7 @@ timer_b=6400
 
 [local-transport-template](!)
 type=transport
-bind=127.0.0.1:5060
+bind=127.0.0.10:5060
 
 [local-transport-udp](local-transport-template)
 protocol=udp
@@ -16,7 +16,7 @@ context=default
 disallow=all
 allow=g722
 allow=ulaw
-media_address=127.0.0.1
+media_address=127.0.0.10
 direct_media=no
 
 ;=========== Alice ===========
@@ -34,7 +34,7 @@ aors=bob-ipv4-udp
 
 [bob-ipv4-udp]
 type=aor
-contact=sip:bob-ipv4-udp@127.0.0.1:5062\;transport=udp
+contact=sip:bob-ipv4-udp@127.0.0.12:5060\;transport=udp
 
 ;===========================
 

--- a/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/requested_capabilities/configs/ast2/pjsip.conf
+++ b/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/requested_capabilities/configs/ast2/pjsip.conf
@@ -5,7 +5,7 @@ timer_b=6400
 
 [local-transport-template](!)
 type=transport
-bind=127.0.0.1:5061
+bind=127.0.0.11:5060
 
 [local-transport-udp](local-transport-template)
 protocol=udp
@@ -16,7 +16,7 @@ context=default
 disallow=all
 allow=g722
 allow=ulaw
-media_address=127.0.0.1
+media_address=127.0.0.11
 direct_media=no
 
 ;== IPv4 & UDP ==
@@ -27,4 +27,4 @@ from_user=alice-ipv4-udp
 
 [uut-ipv4-udp]
 type=aor
-contact=sip:uut-ipv4-udp@127.0.0.1:5060\;transport=udp
+contact=sip:uut-ipv4-udp@127.0.0.10:5060\;transport=udp

--- a/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/requested_capabilities/configs/ast3/pjsip.conf
+++ b/tests/channels/pjsip/basic_calls/two_parties/nominal/alice_initiated/requested_capabilities/configs/ast3/pjsip.conf
@@ -5,7 +5,7 @@ timer_b=6400
 
 [local-transport-template](!)
 type=transport
-bind=127.0.0.1:5062
+bind=127.0.0.12:5060
 
 [local-transport-udp](local-transport-template)
 protocol=udp
@@ -15,7 +15,7 @@ type=endpoint
 context=default
 disallow=all
 allow=ulaw
-media_address=127.0.0.1
+media_address=127.0.0.12
 direct_media=no
 
 [alice-ipv4-udp](endpoint-template-ipv4)


### PR DESCRIPTION
These tests fail with transport "Address already in use" errors
in certain circumstances.  Changing the tests to use a separate
IPv4 address (127.0.0.10, 127.0.0.11, 127.0.0.12) for each asterisk
instance fixes the issue but these tests also did iterations for
IPv6 and IPv6 only allows a single "::1/128" address on the loopback
interface.  Since we have plenty of other tests that test IPv6 and
there was nothing special about these tests that needed IPv6, it's
been removed from them.
