### PR TITLE
pjsip_dtmf_sdp:  Add tests to make sure mismatched digits are generated.

### DIFF
--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/dtmf_sdp_48k_audio_8k_digits_bob/configs/ast1/extensions.conf
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/dtmf_sdp_48k_audio_8k_digits_bob/configs/ast1/extensions.conf
@@ -1,0 +1,23 @@
+[general]
+static=yes
+writeprotect=yes
+autofallthrough=yes
+clearglobalvars=no
+priorityjumping=yes
+
+[globals]
+
+[default]
+exten => 555,1,noOp()
+    same => n,Answer()
+	same => n,SendDTMF(1)
+    same => n,SendDTMF(2)
+    same => n,SendDTMF(3)
+    same => n,SendDTMF(4)
+    same => n,SendDTMF(5)
+    same => n,SendDTMF(6)
+    same => n,SendDTMF(7)
+    same => n,SendDTMF(8)
+    same => n,SendDTMF(9)
+    same => n,SendDTMF(0)
+    same => n,Hangup()

--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/dtmf_sdp_48k_audio_8k_digits_bob/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/dtmf_sdp_48k_audio_8k_digits_bob/configs/ast1/pjsip.conf
@@ -1,0 +1,24 @@
+[global]
+type = global
+debug = yes
+
+[transport-udp]
+type = transport
+protocol = udp
+bind = 0.0.0.0:5060
+
+[endpoint](!)
+type = endpoint
+dtmf_mode = auto_info
+allow = !all,ulaw,alaw,opus
+direct_media = no
+
+[bobmultiopus2]
+type = aor
+max_contacts = 1
+contact = sip:bobmultiopus@127.0.0.1:5069
+
+[bobmultiopus2](endpoint)
+aors = bobmultiopus2
+allow = !all,opus,ulaw,alaw
+

--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/dtmf_sdp_48k_audio_8k_digits_bob/sipp/bob_wants_opus_8kdtmf.xml
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/dtmf_sdp_48k_audio_8k_digits_bob/sipp/bob_wants_opus_8kdtmf.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<scenario name="Basic UAS responder">
+  <recv request="INVITE" crlf="true">
+	<action>
+		<ereg regexp="RTP/AVP 107 0 8 101 102" search_in="body" check_it="true" assign_to = "1" />
+		<ereg regexp="a=rtpmap:0 PCMU/8000" search_in="body" check_it="true" assign_to = "2" />
+		<ereg regexp="a=rtpmap:8 PCMA/8000" search_in="body" check_it="true" assign_to = "3" />
+		<ereg regexp="a=rtpmap:107 opus/48000/2" search_in="body" check_it="true" assign_to = "4" />
+		<ereg regexp="a=rtpmap:101 telephone-event/48000" search_in="body" check_it="true" assign_to = "5" />
+		<ereg regexp="a=fmtp:101 0-16" search_in="body" check_it="true" assign_to = "6" />
+		<ereg regexp="a=rtpmap:102 telephone-event/8000" search_in="body" check_it="true" assign_to = "7" />
+		<ereg regexp="a=fmtp:102 0-16" search_in="body" check_it="true" assign_to = "8" />
+	</action>
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 180 Ringing
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=user1 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+      s=-
+      c=IN IP[media_ip_type] [media_ip]
+      t=0 0
+      m=audio 9000 RTP/AVP 96 102
+      a=sendrecv
+      a=rtpmap:96 opus/48000/2
+      a=fmtp:96 maxplaybackrate=24000;sprop-maxcapturerate=24000;maxaveragebitrate=96000;useinbandfec=1;stereo=1
+      a=rtpmap:102 telephone-event/8000
+      a=fmtp:102 0-16
+
+    ]]>
+  </send>
+
+  <recv request="ACK"
+        optional="true"
+        rtd="true"
+        crlf="true">
+  </recv>
+
+  <recv request="BYE">
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <timewait milliseconds="500"/>
+
+  <Reference variables="1,2,3,4,5,6,7,8"/>
+
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>
+

--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/dtmf_sdp_48k_audio_8k_digits_bob/test-config.yaml
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/dtmf_sdp_48k_audio_8k_digits_bob/test-config.yaml
@@ -1,0 +1,151 @@
+testinfo:
+    summary: 'This test case verifies the use of 2833 digits with a bitrate mismatch on egress'
+    description: |
+        'This test case verifies the use of 2833 digits with a bitrate mismatch on egress where the audio
+        codec is opus but the requested dtmf format sample rate is 8K.y'
+
+properties:
+    dependencies:
+        - app : 'sipp'
+        - asterisk : 'res_pjsip'
+        - asterisk : 'app_dial'
+    tags:
+        - pjsip
+        - refleaks
+
+test-modules:
+    add-test-to-search-path: 'True'
+    test-object:
+        config-section: sipp-config
+        typename: 'sipp_iterator.SIPpIteratorTestCase'
+    modules:
+        -
+            config-section: ami-events
+            typename: 'ami.AMIEventModule'
+        -
+            config-section: ami-config
+            typename: 'pluggable_modules.EventActionModule'
+
+sipp-config:
+    connect-ami: 'True'
+    reactor-timeout: 30
+    type: 'single'
+    scenarios:
+        # Asterisk offers multiple codecs, opus prioritized with ulaw and Alaw as options.
+        - { 'scenario': {'Name': 'bob_wants_opus_8kdtmf.xml', 'port': '5069', 'target': '127.0.0.1', 'ordered-args': {'-s','bobmultiopus2'}},
+            'action': {'Action': 'Originate', 'Channel': 'PJSIP/bobmultiopus2', 'Exten':'555', 'Priority':'1', 'context':'default', 'CallerID':'Asterisk Testsuite <900>'}}
+        # indicate no more scenarios to run, send testComplete Event
+        - { 'scenario': {'Name': 'done'},
+            'action': {'Action': 'UserEvent', 'UserEvent': 'testComplete'}}
+
+ami-events:
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '1'
+                    Payload: '102'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '2'
+                    Payload: '102'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '3'
+                    Payload: '102'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '4'
+                    Payload: '102'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '5'
+                    Payload: '102'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '6'
+                    Payload: '102'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '7'
+                    Payload: '102'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '8'
+                    Payload: '102'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '9'
+                    Payload: '102'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '0'
+                    Payload: '102'
+                    rate: '8000'
+        count: '1'
+
+ami-config:
+    -
+        ami-events:
+            conditions:
+                match:
+                    Event: 'UserEvent'
+                    UserEvent: 'testComplete'
+            count: 1
+        stop_test:

--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/dtmf_sdp_48k_priority_match_8k_digits/configs/ast1/extensions.conf
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/dtmf_sdp_48k_priority_match_8k_digits/configs/ast1/extensions.conf
@@ -1,0 +1,23 @@
+[general]
+static=yes
+writeprotect=yes
+autofallthrough=yes
+clearglobalvars=no
+priorityjumping=yes
+
+[globals]
+
+[default]
+exten => 555,1,noOp()
+    same => n,Answer()
+	same => n,SendDTMF(1)
+    same => n,SendDTMF(2)
+    same => n,SendDTMF(3)
+    same => n,SendDTMF(4)
+    same => n,SendDTMF(5)
+    same => n,SendDTMF(6)
+    same => n,SendDTMF(7)
+    same => n,SendDTMF(8)
+    same => n,SendDTMF(9)
+    same => n,SendDTMF(0)
+    same => n,Hangup()

--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/dtmf_sdp_48k_priority_match_8k_digits/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/dtmf_sdp_48k_priority_match_8k_digits/configs/ast1/pjsip.conf
@@ -1,0 +1,21 @@
+[global]
+type = global
+debug = yes
+
+[transport-udp]
+type = transport
+protocol = udp
+bind = 0.0.0.0:5060
+
+[endpoint](!)
+type = endpoint
+dtmf_mode = auto_info
+allow = !all,ulaw,alaw,opus
+direct_media = no
+
+[alicepriorityopus](endpoint)
+allow = !all,opus,ulaw
+
+[alicepriorityopus]
+type=aor
+max_contacts = 10

--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/dtmf_sdp_48k_priority_match_8k_digits/sipp/alice_opus-amr16-ulaw_opus-ulaw.xml
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/dtmf_sdp_48k_priority_match_8k_digits/sipp/alice_opus-amr16-ulaw_opus-ulaw.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<scenario name="DTMF_SDP_NEGOTIATON_ALICE">
+<!-- Agent offers multiple codecs, opus prioritized with ulaw as options.  Asterisk prioritizes opus. -->
+
+<send retrans="500">
+	<![CDATA[
+
+	INVITE sip:555@[remote_ip] SIP/2.0
+	Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+	From: [service] <sip:[service]@[local_ip]>;tag=[call_number]
+	To: 555 <sip:555@[remote_ip]:[remote_port]>
+	Call-ID: [call_id]
+	CSeq: 1 INVITE
+	Contact: sip:[service]@[local_ip]:[local_port]
+	Max-Forwards: 70
+	Subject: Performance Test
+	Content-Type: application/sdp
+	Content-Length: [len]
+
+	v=0
+	o=user1 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+	s=-
+	c=IN IP[local_ip_type] [local_ip]
+	t=0 0
+	m=audio 9000 RTP/AVP 96 97 0 101
+	a=sendrecv
+	a=rtpmap:96 opus/48000/2
+	a=fmtp:96 maxplaybackrate=24000;sprop-maxcapturerate=24000;maxaveragebitrate=96000;useinbandfec=1
+	a=rtpmap:97 AMR-WB/16000
+	a=fmtp:97 octet-align=1
+	a=rtpmap:0 PCMU/8000
+	a=rtpmap:101 telephone-event/8000
+	a=fmtp:101 0-16
+
+
+	]]>
+</send>
+
+<recv response="100" optional="true"/>
+
+<recv response="180" optional="true"/>
+
+<recv response="200" crlf="true">
+	<action>
+		<ereg regexp="RTP/AVP 96 0 101" search_in="body" check_it="true" assign_to = "1" />
+		<ereg regexp="a=rtpmap:96 opus/48000/2" search_in="body" check_it="true" assign_to = "2" />
+		<ereg regexp="a=fmtp:96 maxplaybackrate=24000;sprop-maxcapturerate=24000;maxaveragebitrate=96000" search_in="body" check_it="true" assign_to = "3" />
+		<ereg regexp="a=rtpmap:0 PCMU/8000" search_in="body" check_it="true" assign_to = "4" />
+		<ereg regexp="a=rtpmap:101 telephone-event/8000" search_in="body" check_it="true" assign_to = "5" />
+		<ereg regexp="a=fmtp:101 0-16" search_in="body" check_it="true" assign_to = "6" />
+	</action>
+</recv>
+
+<send>
+	<![CDATA[
+
+	ACK sip:[service]@[remote_ip] SIP/2.0
+	Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+	From: [service] <sip:[service]@[local_ip]:[local_port]>;tag=[call_number]
+	To: 555 <sip:555@[remote_ip]>[peer_tag_param]
+	Call-ID: [call_id]
+	CSeq: 1 ACK
+	Contact: sip:[service]@[local_ip]:[local_port]
+	Max-Forwards: 70
+	Subject: Performance Test
+	Content-Length: 0
+
+	]]>
+</send>
+
+
+<recv request="BYE" timeout="15000" ontimeout="sendbye" next="respond">
+</recv>
+
+<label id="sendbye"/>
+
+<send retrans="500">
+	<![CDATA[
+
+	BYE sip:[service]@[remote_ip] SIP/2.0
+	Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+	From: sipp <sip:test@[local_ip]:[local_port]>;tag=[call_number]
+	To: sut <sip:[service]@[remote_ip]>[peer_tag_param]
+	Call-ID: [call_id]
+	CSeq: 2 BYE
+	Contact: sip:[service]@[local_ip]:[local_port]
+	Max-Forwards: 70
+	Subject: Performance Test
+	Content-Length: 0
+
+	]]>
+</send>
+
+<recv response="200" crlf="true" next="end"/>
+
+<label id="respond"/>
+
+<send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+
+    ]]>
+</send>
+
+<label id="end"/>
+
+<Reference variables="1,2,3,4,5,6"/>
+
+</scenario>

--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/dtmf_sdp_48k_priority_match_8k_digits/test-config.yaml
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/dtmf_sdp_48k_priority_match_8k_digits/test-config.yaml
@@ -1,0 +1,133 @@
+testinfo:
+    summary: 'This test case verifies the use of 2833 digits with multiple bitrate codecs'
+    description: |
+        'This test case verifies the use of 2833 digits with multiple bitrate codecs in different combinations'
+
+properties:
+    dependencies:
+        - app : 'sipp'
+        - asterisk : 'res_pjsip'
+        - asterisk : 'app_dial'
+        - buildoption: 'TEST_FRAMEWORK'
+    tags:
+        - pjsip
+
+test-modules:
+    test-object:
+        typename: sipp.SIPpTestCase
+        config-section: sipp-config
+    modules:
+        -
+            config-section: ami-events
+            typename: 'ami.AMIEventModule'
+
+sipp-config:
+    connect-ami: True
+    reactor-timeout: 90
+    fail-on-any: False
+    test-iterations:
+        -
+            scenarios:
+                - { 'key-args': {'scenario': 'alice_opus-amr16-ulaw_opus-ulaw.xml', '-p': '5061', '-s': 'alicepriorityopus'} }
+
+ami-events:
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '1'
+                    Payload: '101'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '2'
+                    Payload: '101'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '3'
+                    Payload: '101'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '4'
+                    Payload: '101'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '5'
+                    Payload: '101'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '6'
+                    Payload: '101'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '7'
+                    Payload: '101'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '8'
+                    Payload: '101'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '9'
+                    Payload: '101'
+                    rate: '8000'
+        count: '1'
+    -
+        type: 'headermatch'
+        conditions:
+            match:
+                    Event: 'TestEvent'
+                    state: 'DTMF_BEGIN'
+                    Digit: '0'
+                    Payload: '101'
+                    rate: '8000'
+        count: '1'

--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/tests.yaml
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_generation/tests.yaml
@@ -2,4 +2,6 @@ tests:
     - test: 'dtmf_sdp_8k_priority_match'
     - test: 'dtmf_sdp_8k_priority_diff'
     - test: 'dtmf_sdp_48k_priority_match'
+    - test: 'dtmf_sdp_48k_priority_match_8k_digits'
     - test: 'dtmf_sdp_48k_priority_diff'
+    - test: 'dtmf_sdp_48k_audio_8k_digits_bob'

--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_negotiation_bob/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_negotiation_bob/configs/ast1/pjsip.conf
@@ -31,6 +31,15 @@ contact = sip:bobmultiopus@127.0.0.1:5066
 aors = bobmultiopus
 allow = !all,opus,ulaw,alaw
 
+[bobmultiopus2]
+type = aor
+max_contacts = 1
+contact = sip:bobmultiopus@127.0.0.1:5069
+
+[bobmultiopus2](endpoint)
+aors = bobmultiopus2
+allow = !all,opus,ulaw,alaw
+
 [bobonlyulaw]
 type = aor
 max_contacts = 1

--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_negotiation_bob/sipp/bob_wants_opus_8kdtmf.xml
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_negotiation_bob/sipp/bob_wants_opus_8kdtmf.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<scenario name="Basic UAS responder">
+  <recv request="INVITE" crlf="true">
+	<action>
+		<ereg regexp="RTP/AVP 107 0 8 101 102" search_in="body" check_it="true" assign_to = "1" />
+		<ereg regexp="a=rtpmap:0 PCMU/8000" search_in="body" check_it="true" assign_to = "2" />
+		<ereg regexp="a=rtpmap:8 PCMA/8000" search_in="body" check_it="true" assign_to = "3" />
+		<ereg regexp="a=rtpmap:107 opus/48000/2" search_in="body" check_it="true" assign_to = "4" />
+		<ereg regexp="a=rtpmap:101 telephone-event/48000" search_in="body" check_it="true" assign_to = "5" />
+		<ereg regexp="a=fmtp:101 0-16" search_in="body" check_it="true" assign_to = "6" />
+		<ereg regexp="a=rtpmap:102 telephone-event/8000" search_in="body" check_it="true" assign_to = "7" />
+		<ereg regexp="a=fmtp:102 0-16" search_in="body" check_it="true" assign_to = "8" />
+	</action>
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 180 Ringing
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=user1 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+      s=-
+      c=IN IP[media_ip_type] [media_ip]
+      t=0 0
+      m=audio 9000 RTP/AVP 96 102
+      a=sendrecv
+      a=rtpmap:96 opus/48000/2
+      a=fmtp:96 maxplaybackrate=24000;sprop-maxcapturerate=24000;maxaveragebitrate=96000;useinbandfec=1;stereo=1
+      a=rtpmap:102 telephone-event/8000
+      a=fmtp:102 0-16
+
+    ]]>
+  </send>
+
+  <recv request="ACK"
+        optional="true"
+        rtd="true"
+        crlf="true">
+  </recv>
+
+  <recv request="BYE">
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <timewait milliseconds="500"/>
+
+  <Reference variables="1,2,3,4,5,6,7,8"/>
+
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>
+

--- a/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_negotiation_bob/test-config.yaml
+++ b/tests/channels/pjsip/dtmf_sdp/dtmf_sdp_negotiation_bob/test-config.yaml
@@ -36,6 +36,9 @@ sipp-config:
         # Asterisk offers multiple codecs, opus prioritized with ulaw and Alaw as options.
         - { 'scenario': {'Name': 'bob_wants_opus.xml', 'port': '5066', 'target': '127.0.0.1', 'ordered-args': {'-s','bobmultiopus'}},
             'action': {'Action': 'Originate', 'Channel': 'PJSIP/bobmultiopus', 'Exten':'555', 'Priority':'1', 'context':'default', 'CallerID':'Asterisk Testsuite <900>'}}
+        # Asterisk offers multiple codecs, opus prioritized with ulaw and Alaw as options.
+        - { 'scenario': {'Name': 'bob_wants_opus_8kdtmf.xml', 'port': '5069', 'target': '127.0.0.1', 'ordered-args': {'-s','bobmultiopus2'}},
+            'action': {'Action': 'Originate', 'Channel': 'PJSIP/bobmultiopus2', 'Exten':'555', 'Priority':'1', 'context':'default', 'CallerID':'Asterisk Testsuite <900>'}}
         # Asterisk offers multiple codecs, ulaw prioritized with opus and Alaw as options.
         - { 'scenario': {'Name': 'bob_wants_ulaw.xml', 'port': '5065', 'target': '127.0.0.1', 'ordered-args': {'-s','bobmultiulaw'}},
             'action': {'Action': 'Originate', 'Channel': 'PJSIP/bobmultiulaw', 'Exten':'555', 'Priority':'1', 'context':'default', 'CallerID':'Asterisk Testsuite <900>'}}


### PR DESCRIPTION
Add tests to make sure that when Bob negotiates for 8K digits with a 48K
audio codec, the correct payload is generated.

Fixes: #847
