### PR TITLE
Updates for running the testsuite using realtime database

### DIFF
--- a/lib/python/asterisk/astconfigparser.py
+++ b/lib/python/asterisk/astconfigparser.py
@@ -106,7 +106,7 @@ class Section(MultiOrderedDict):
         keys from this section's defaults and templates are not
         included in the returned value
         """
-        res = MultiOrderedDict.keys(self)
+        res = list(MultiOrderedDict.keys(self))
         if self_only:
             return res
 
@@ -119,7 +119,7 @@ class Section(MultiOrderedDict):
             for key in d.keys():
                 if key not in res:
                     res.append(key)
-        return list(res.keys())
+        return res
 
     def add_defaults(self, defaults):
         """

--- a/requirements-realtime.txt
+++ b/requirements-realtime.txt
@@ -1,0 +1,5 @@
+# These packages are required if running the testsuite with
+# the realtime_converter
+SQLAlchemy==2.0.30
+alembic==1.13.1
+psycopg2==2.9.9

--- a/setupVenv.sh
+++ b/setupVenv.sh
@@ -1,14 +1,25 @@
 #!/usr/bin/env bash
 set -e
 
+REALTIME=false
+declare -a VENV_ARGS
+
+for a in "$@" ; do
+	if [ "$a" == "--realtime" ] ; then
+		REALTIME=true
+	else
+		VENV_ARGS+=( "$a" )
+	fi
+done
+
 function do_pip_setup {
 	python3 -m pip install --upgrade pip
 	python3 -m pip install wheel setuptools build
 	python3 -m pip install -r ./requirements.txt
 	python3 -m pip install -r ./extras.txt
-	md5sum requirements.txt extras.txt > $1/checksums
+	$REALTIME && python3 -m pip install -r ./requirements-realtime.txt
+	md5sum requirements.txt extras.txt requirements-realtime.txt > $1/checksums
 }
-
 
 if [[ "$VIRTUAL_ENV" != "" ]]
 then
@@ -16,7 +27,7 @@ then
 	echo "Skipping creation of new environment, configuring"
 	do_pip_setup $VIRTUAL_ENV
 else
-	python3 -m venv $@ .venv
+	python3 -m venv ${VENV_ARGS[@]} .venv
 	source .venv/bin/activate
 	echo "Activated virtual environment:" $VIRTUAL_ENV
 	if [[ "$VIRTUAL_ENV" != "" ]]


### PR DESCRIPTION
* Fix python3 MultiOrderedDict.keys() issue in astconfigparser.py.
* Updated realtime_converter.py to be compatible with SQLAlchemy 2.
* Added requirements-realtime.txt to install SQLAlchemy, alembic and
  psycopg2.
* Updated setupVenv.sh to install from requirements-realtime.txt
  if the `--realtime` argument was passed in.
