### PR TITLE
dial_progress: Fix broken progress timeout test.

### DIFF
--- a/tests/apps/dial/dial_progress/test-config.yaml
+++ b/tests/apps/dial/dial_progress/test-config.yaml
@@ -1,9 +1,4 @@
 testinfo:
-    skip: |
-        'app_dial doesn't implement this correctly.  There\'s also a bug
-        in this tests\'s extensions conf where it doesn't actually contain
-        the "nothing" context referenced in the caller-originate config
-        section. See GitHub #821'
     summary: 'Ensure that Dial progress timer works correctly.'
     description: |
         'This tests the Dial application aborts if progress is not received
@@ -29,7 +24,7 @@ test-object-config:
 
 caller-originator:
     channel: 'Local/s@default'
-    context: 'nothing'
+    context: 'noanswer'
     exten: '0'
     priority: '1'
     trigger: 'ami_connect'


### PR DESCRIPTION
Resolves an issue with bridging to an undefined context and re-enables the test following an underlying bug with the feature being fixed.