### PR TITLE
dial_progress: Fix originate and improve test robustness.

### DIFF
--- a/tests/apps/dial/dial_progress/configs/ast1/extensions.conf
+++ b/tests/apps/dial/dial_progress/configs/ast1/extensions.conf
@@ -4,8 +4,8 @@ exten => s,1,Answer()
 	same => n,UserEvent(DialProgress,Result: Pass)
 	same => n,Dial(Local/s@earlymedia,3^2) ; we should get early media, so that will "lock" in this call and we'll wait up to 3 seconds, resulting in a normal NOANSWER
 	same => n,ExecIf($["${DIALSTATUS}"="NOANSWER"]?UserEvent(DialProgress,Result: Pass))
-	same => n,Dial(Local/s@answer,3^2) ; call will answer, so should not continue
-	same => n,UserEvent(DialProgress,Result: Fail)
+	same => n,Dial(Local/s@answer,3^2,g) ; call will answer, and will continue
+	same => n,ExecIf($["${DIALSTATUS}"="ANSWER"]?UserEvent(DialProgress, Result: Pass))
 	same => n,Hangup()
 
 [noanswer]

--- a/tests/apps/dial/dial_progress/test-config.yaml
+++ b/tests/apps/dial/dial_progress/test-config.yaml
@@ -13,9 +13,6 @@ test-modules:
             config-section: caller-originator
             typename: 'pluggable_modules.Originator'
         -
-            config-section: hangup-monitor
-            typename: 'pluggable_modules.HangupMonitor'
-        -
             config-section: ami-config
             typename: 'pluggable_modules.EventActionModule'
 
@@ -25,12 +22,9 @@ test-object-config:
 caller-originator:
     channel: 'Local/s@default'
     context: 'noanswer'
-    exten: '0'
+    exten: 's'
     priority: '1'
     trigger: 'ami_connect'
-
-hangup-monitor:
-    ids: '0'
 
 ami-config:
     -
@@ -42,7 +36,14 @@ ami-config:
             requirements:
                 match:
                     Result: 'Pass'
-            count: 2
+            count: 3
+    -
+        ami-events:
+            conditions:
+                match:
+                    Event: 'Hangup'
+                    Channel: 'Local/s@default-00000000;1'
+            count: 1
         stop_test:
 
 properties:


### PR DESCRIPTION
* Fix originate to extension '0' instead of 's' as in dialplan.
* Eliminate the Fail UserEvent if we continue past the pass dials. Previously, the test suite would initiate shutdown as soon as 2 passes were received, which caused the answer dial channel allocation to fail, leading dialplan execution to continue onwards to stuff it wasn't supposed to execute in a successful test, triggering a failure. To test the same scenario, explicitly continue onwards and check DIALSTATUS for an additional pass, which should prevent us from getting shut down before the test has concluded.