### PR TITLE
pjsip/rest_api: Introduce a test for ChannelTransfer event

### DIFF
--- a/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_app_ari_only/configs/ast1/extensions.conf
+++ b/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_app_ari_only/configs/ast1/extensions.conf
@@ -1,0 +1,14 @@
+[default]
+
+exten => s,1,NoOp()
+	same => n,Answer()
+	same => n,Stasis(testsuite)
+	same => n,Hangup()
+
+exten => 1000,1,Answer
+	same => n,Stasis(testsuite,no_bridge)
+	same => n,Hangup
+
+exten => stasis,1,NoOp()
+	same => n,Answer()
+	same => n,Stasis(testsuite,test)

--- a/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_app_ari_only/configs/ast1/pjsip.conf
+++ b/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_app_ari_only/configs/ast1/pjsip.conf
@@ -1,0 +1,12 @@
+[local]
+type=transport
+protocol=udp
+bind=127.0.0.1:5060
+
+[bob]
+type=endpoint
+context=default
+disallow=all
+allow=ulaw
+direct_media=no
+set_var=PJSIP_TRANSFER_HANDLING()=ari-only

--- a/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_app_ari_only/sipp/referee.xml
+++ b/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_app_ari_only/sipp/referee.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- This program is free software; you can redistribute it and/or      -->
+<!-- modify it under the terms of the GNU General Public License as     -->
+<!-- published by the Free Software Foundation; either version 2 of the -->
+<!-- License, or (at your option) any later version.                    -->
+<!--                                                                    -->
+<!-- This program is distributed in the hope that it will be useful,    -->
+<!-- but WITHOUT ANY WARRANTY; without even the implied warranty of     -->
+<!-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the      -->
+<!-- GNU General Public License for more details.                       -->
+<!--                                                                    -->
+<!-- You should have received a copy of the GNU General Public License  -->
+<!-- along with this program; if not, write to the                      -->
+<!-- Free Software Foundation, Inc.,                                    -->
+<!-- 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA             -->
+<!--                                                                    -->
+
+<scenario name="Referee Leg">
+
+  <recvCmd>
+    <action>
+      <ereg regexp="REMOTE(.*)"
+        search_in="hdr"
+        header="Call-ID:"
+        check_it="true"
+        assign_to="1,original_callid" />
+    </action>
+  </recvCmd>
+
+  <send retrans="500">
+    <![CDATA[
+
+      INVITE sip:1000@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: <sip:bob@[local_ip]:[local_port]>;tag=[call_number]
+      To: <sip:transfer@[remote_ip]:[remote_port]>
+      Call-ID: [call_id]
+      CSeq: [cseq] INVITE
+      Contact: <sip:bob@[local_ip]:[local_port]>
+      Max-Forwards: 70
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=- 1324901698 1324901698 IN IP[local_ip_type] [local_ip]
+      s=-
+      c=IN IP[media_ip_type] [media_ip]
+      t=0 0
+      m=audio [media_port] RTP/AVP 0 101
+      a=sendrecv
+      a=rtpmap:0 PCMU/8000
+      a=rtpmap:101 telephone-event/8000
+
+    ]]>
+  </send>
+
+  <recv response="100" optional="true" />
+  <recv response="101" optional="true" />
+  <recv response="180" optional="true" />
+  <recv response="200" rtd="true" crlf="true">
+    <action>
+      <ereg regexp="tag=([[:alnum:].\-]*)"
+        search_in="hdr"
+        header="To:"
+        check_it="true"
+        assign_to="2,to_tag" />
+      <ereg regexp="tag=([[:alnum:].\-]*)"
+        search_in="hdr"
+        header="From:"
+        check_it="true"
+        assign_to="3,from_tag" />
+    </action>
+  </recv>
+  <Reference variables="1,2,3" />
+
+  <send>
+    <![CDATA[
+
+      ACK sip:1000@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];rport;branch=[branch]
+      [last_From:]
+      [last_To]
+      Call-ID: [call_id]
+      CSeq: [cseq] ACK
+      Contact: sip:bob@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <pause milliseconds="1000" />
+  <sendCmd>
+    <![CDATA[
+      Call-ID: [$original_callid]
+      Remote-To-Tag: [$to_tag]
+      Remote-From-Tag: [$from_tag]
+      Remote-URI: sip:1000@[remote_ip]:[remote_port]
+    ]]>
+  </sendCmd>
+
+  <recv request="BYE" />
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:bob@[local_ip]:[local_port]>
+      Content-Length:0
+
+    ]]>
+  </send>
+
+  <!-- definition of the response time repartition table (unit is ms)   -->
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+
+  <!-- definition of the call length repartition table (unit is ms)     -->
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>

--- a/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_app_ari_only/sipp/referer.xml
+++ b/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_app_ari_only/sipp/referer.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- This program is free software; you can redistribute it and/or      -->
+<!-- modify it under the terms of the GNU General Public License as     -->
+<!-- published by the Free Software Foundation; either version 2 of the -->
+<!-- License, or (at your option) any later version.                    -->
+<!--                                                                    -->
+<!-- This program is distributed in the hope that it will be useful,    -->
+<!-- but WITHOUT ANY WARRANTY; without even the implied warranty of     -->
+<!-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the      -->
+<!-- GNU General Public License for more details.                       -->
+<!--                                                                    -->
+<!-- You should have received a copy of the GNU General Public License  -->
+<!-- along with this program; if not, write to the                      -->
+<!-- Free Software Foundation, Inc.,                                    -->
+<!-- 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA             -->
+<!--                                                                    -->
+
+<scenario name="Referer Leg">
+
+  <send retrans="500">
+    <![CDATA[
+
+      INVITE sip:stasis@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: <sip:bob@[local_ip]:[local_port]>;tag=[call_number]
+      To: <sip:transfer@[remote_ip]:[remote_port]>
+      Call-ID: [call_id]
+      CSeq: [cseq] INVITE
+      Contact: <sip:bob@[local_ip]:[local_port]>
+      Content-Type: application/sdp
+      Max-Forwards: 70
+      Content-Length: [len]
+
+      v=0
+      o=- 1324901698 1324901698 IN IP[local_ip_type] [local_ip]
+      s=-
+      c=IN IP[media_ip_type] [media_ip]
+      t=0 0
+      m=audio [media_port] RTP/AVP 0 101
+      a=sendrecv
+      a=rtpmap:0 PCMU/8000
+      a=rtpmap:101 telephone-event/8000
+
+    ]]>
+  </send>
+
+  <recv response="100" optional="true" />
+  <recv response="101" optional="true" />
+  <recv response="180" optional="true" />
+  <recv response="200" rtd="true" crlf="true" />
+
+  <send>
+    <![CDATA[
+
+      ACK sip:stasis@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];rport;branch=[branch]
+      [last_From:]
+      [last_To]
+      Call-ID: [call_id]
+      CSeq: [cseq] ACK
+      Contact: sip:bob@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <sendCmd>
+    <![CDATA[
+      Call-ID: REMOTE[call_id]
+      Start the Echo Leg
+    ]]>
+  </sendCmd>
+
+  <recvCmd>
+    <action>
+      <ereg regexp=" (.+)"
+        search_in="hdr"
+        header="Remote-URI:"
+        check_it="true"
+        assign_to="1,remote_contact" />
+      <ereg regexp=" (.+)"
+        search_in="hdr"
+        header="Remote-To-Tag:"
+        check_it="true"
+        assign_to="2,remote_to_tag" />
+      <ereg regexp=" (.+)"
+        search_in="hdr"
+        header="Remote-From-Tag:"
+        check_it="true"
+        assign_to="3,remote_from_tag" />
+      <ereg regexp=" (.+)@(.+)"
+        search_in="hdr"
+        header="Call-ID:"
+        check_it="true"
+        assign_to="4,callid_chunk_1,callid_chunk_2"/>
+     </action>
+  </recvCmd>
+  <Reference variables="1,2,3,4" />
+
+  <send>
+    <![CDATA[
+
+      REFER sip:stasis@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      [last_From:]
+      [last_To]
+      [last_Call-ID:]
+      CSeq: [cseq] REFER
+      Contact: <sip:bob@[local_ip]:[local_port]>
+      Max-Forwards: 70
+      Refer-to: <[$remote_contact]?Replaces=REMOTE[$callid_chunk_1]%40[$callid_chunk_2]%3Bto-tag%3D[$remote_to_tag]%3Bfrom-tag%3D[$remote_from_tag]>
+      Referred-By: sip:bob@[local_ip]
+      Content-Length: 0
+
+    ]]>
+  </send>
+  <recv response="202" rtd="true" crlf="true" />
+
+  <recv request="NOTIFY" />
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:bob@[local_ip]:[local_port]>
+      Content-Length:0
+
+    ]]>
+  </send>
+
+  <recv request="NOTIFY" />
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:bob@[local_ip]:[local_port]>
+      Content-Length:0
+
+    ]]>
+    </send>
+
+  <send retrans="500">
+    <![CDATA[
+
+      BYE sip:stasis@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: <sip:bob@[local_ip]:[local_port]>;tag=[call_number]
+      To: <sip:transfer@[remote_ip]:[remote_port]>[peer_tag_param]
+      [last_Call-ID:]
+      CSeq: [cseq] BYE
+      Contact: sip:bob@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Subject: Performance Test
+      Content-Length: 0
+
+    ]]>
+  </send>
+  <recv response="200" />
+
+  <!-- definition of the response time repartition table (unit is ms)   -->
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+
+  <!-- definition of the call length repartition table (unit is ms)     -->
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>

--- a/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_app_ari_only/test-config.yaml
+++ b/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_app_ari_only/test-config.yaml
@@ -1,0 +1,166 @@
+testinfo:
+    summary: |
+        "Verifies that appropriate ChannelTransfer, StasisStart,
+        and StasisEnd events are delivered when an ari-only transfer
+        occurs between a Stasis App and a Stasis Bridge."
+    description: |
+        "This test originates one call into Stasis():
+
+          Originated Channel -> Stasis(testsuite)
+
+        It then starts two SIPp scenarios that call into the dialplan:
+
+          SIPp #1 (referer.xml) -> Stasis(testsuite)
+          SIPp #2 (referee.xml) -> Stasis(testsuite,no_bridge)
+
+        The two SIPp scenarios work together via 3PCC mode to pass
+        SIPp #2's call information back to SIPp #1 once both calls are up:
+
+          SIPp #2 --3PCC(call information)-> SIPp #1
+
+        The test bridges the two channels in Stasis(testsuite):
+
+          Originated Channel -> Stasis(testsuite) -> Bridge -> Stasis(testsuite) -> SIPp #1
+
+        SIPp #1 then performs an attended transfer using a REFER with
+        SIPp #2's call information which results in a ChannelTransferEvent with
+        the right information.
+
+        Now that we have received the ChannelTransfer event we can delete the
+        channels and the test eneds."
+
+test-modules:
+    test-object:
+        typename: ari.AriTestObject
+    modules:
+        -
+            config-section: pluggable-config
+            typename: 'pluggable_modules.EventActionModule'
+
+pluggable-config:
+    -
+        ari-events:
+            match:
+                type: StasisStart
+                application: testsuite
+                args: []
+                channel:
+                    name: 'Local/s@default-.*'
+            count: 1
+        ari-requests:
+            -
+                method: 'post'
+                uri: 'bridges/test_bridge'
+            -
+                method: 'post'
+                uri: 'bridges/test_bridge/addChannel'
+                params:
+                    channel: '{channel.id}'
+        callback:
+            module: extension_bank
+            method: default_attended_transfer
+    -
+        ari-events:
+            match:
+                type: StasisStart
+                application: testsuite
+                args: ['test']
+            count: 1
+        ari-requests:
+            method: 'post'
+            uri: 'bridges/test_bridge/addChannel'
+            params:
+                channel: '{channel.id}'
+    -
+        ari-events:
+            match:
+                type: StasisStart
+                application: testsuite
+                args: ['no_bridge']
+            count: 1
+    -
+        ari-events:
+            match:
+                type: ChannelTransfer
+                refer_to:
+                  destination_channel:
+                    name: 'PJSIP/bob-.*'
+                    dialplan:
+                      app_data: 'testsuite,no_bridge'
+                      app_name: 'Stasis'
+                      context: 'default'
+                      exten: '1000'
+                  requested_destination:
+                    destination: '1000'
+                    protocol_id: 'REMOTE1-.*'
+                    additional_protocol_params:
+                      - parameter_name: 'from'
+                        parameter_value: '1'
+                      - parameter_name: 'to'
+                        parameter_value: '.*'
+                referred_by:
+                  bridge:
+                    id: 'test_bridge'
+                  connected_channel:
+                    name: 'Local/s.*'
+                  source_channel:
+                    name: 'PJSIP/bob-.*'
+                    dialplan:
+                      app_data: 'testsuite,test'
+            nomatch:
+                state: 'channel.*'
+            count: 1
+        ari-requests:
+            -
+                method: 'post'
+                uri: 'channels/{referred_by.source_channel.id}/transfer_progress'
+                params:
+                  states: 'channel_progress'
+    -
+        ari-events:
+            match:
+                type: ChannelTransfer
+                refer_to:
+                  requested_destination:
+                    destination: '1000'
+                state: 'channel_progress'
+            count: 1
+        ari-requests:
+            -
+                method: 'post'
+                uri: 'channels/{referred_by.source_channel.id}/transfer_progress'
+                params:
+                  states: 'channel_answered'
+    -
+        ari-events:
+            match:
+                type: ChannelTransfer
+                refer_to:
+                  requested_destination:
+                    destination: '1000'
+                state: 'channel_answered'
+            count: 1
+        ari-requests:
+            -
+                method: 'delete'
+                uri: 'channels/{referred_by.connected_channel.id}'
+            -
+                method: 'delete'
+                uri: 'channels/{refer_to.destination_channel.id}'
+            -
+                method: 'delete'
+                uri: 'bridges/test_bridge'
+
+properties:
+    dependencies:
+        - python : autobahn.websocket
+        - python : requests
+        - python : twisted
+        - python : starpy
+        - asterisk : res_ari_channels
+        - asterisk : res_ari_bridges
+        - asterisk : chan_pjsip
+    tags:
+        - ARI
+        - pjsip
+        - refleaks

--- a/tests/rest_api/external_interaction/attended_transfer/tests.yaml
+++ b/tests/rest_api/external_interaction/attended_transfer/tests.yaml
@@ -1,7 +1,7 @@
 tests:
     - test: 'stasis_bridge_to_non_stasis_app'
     - test: 'stasis_bridge_to_stasis_app'
+    - test: 'stasis_bridge_to_stasis_app_ari_only'
     - test: 'non_stasis_app_to_stasis_bridge'
     - test: 'non_stasis_bridge_to_stasis_bridge'
     - dir: 'stasis_bridge_to_stasis_bridge'
-


### PR DESCRIPTION
Test that a SIP REFER is translated into a ChannelTransfer event when TRANSFERHANDLING=ari-only is set on the channel and that transfer_progress generates the necessary SIP NOTIFY messages.

Be strict on the first ChannelTransfer event being received. Then only check that the transfer state is changing from not being present, to progress and finally answered. When answered delete all the channels and the bridge and the test wull succeed.