### PR TITLE
manager: Add scenarios to the config/restricted test.

### DIFF
--- a/tests/manager/action-events-response/test-config.yaml
+++ b/tests/manager/action-events-response/test-config.yaml
@@ -1,5 +1,6 @@
 testinfo:
     summary:     'Test the presence and absence of a response from the Events manager action'
+    skip: 'Lua test that needs to be updated'
     description: |
         "This test ensure asterisk either responds or does not respond to
         various values of the EventMaks parameter of the Events manager

--- a/tests/manager/authlimit/test-config.yaml
+++ b/tests/manager/authlimit/test-config.yaml
@@ -1,5 +1,6 @@
 testinfo:
     summary:     'Test the authlimit manager config option.'
+    skip: 'Lua test that needs to be updated'
     description: |
         "This test ensures that the manager respects the authlimit config
         option."

--- a/tests/manager/authtimeout/test-config.yaml
+++ b/tests/manager/authtimeout/test-config.yaml
@@ -1,5 +1,6 @@
 testinfo:
     summary:     'Test the authtimeout manager config option.'
+    skip: 'Lua test that needs to be updated'
     description: |
         "This test ensures that the manager respects the authtimeout config
         option."

--- a/tests/manager/config/restricted/test-config.yaml
+++ b/tests/manager/config/restricted/test-config.yaml
@@ -24,13 +24,34 @@ object-config:
     reactor-timeout: 15
     testfile: '/tmp/test.conf'
     ami-config:
-        - ###  Create a new config file outside the asterisk config directory
+        - ###  Create a config file outside the asterisk config directory
+            message:
+                Action: 'CreateConfig'
+                Filename: '/tmp/test.conf'
+            expected:
+                Response: 'Error'
+                Message: 'File requires escalated privileges'
+        - ###  Create a config file outside the asterisk config directory
+            message:
+                Action: 'CreateConfig'
+                Filename: '../test.conf'
+            expected:
+                Response: 'Error'
+                Message: 'File requires escalated privileges'
+        - ###  Create a config file outside the asterisk config directory
+            message:
+                Action: 'CreateConfig'
+                Filename: '/etc/asterisk/../test.conf'
+            expected:
+                Response: 'Error'
+                Message: 'File requires escalated privileges'
+        - ###  Retrieve a config file outside the asterisk config directory
             message:
                 Action: 'GetConfig'
                 Filename: '/tmp/test.conf'
             expected:
                 Response: 'Error'
-                Message: 'File requires escalated priveledges'
+                Message: 'File requires escalated privileges'
         - ###  Update a config file outside the asterisk config directory
             message:
                 Action: 'UpdateConfig'
@@ -41,7 +62,7 @@ object-config:
                 Cat-000000: 'Cat1'
             expected:
                 Response: 'Error'
-                Message: 'File requires escalated priveledges'
+                Message: 'File requires escalated privileges'
         - ###  Update from a config file outside the asterisk config directory
             message:
                 Action: 'UpdateConfig'
@@ -52,7 +73,7 @@ object-config:
                 Cat-000000: 'Cat1'
             expected:
                 Response: 'Error'
-                Message: 'File requires escalated priveledges'
+                Message: 'File requires escalated privileges'
         - ###  Update to a config file outside the asterisk config directory
             message:
                 Action: 'UpdateConfig'
@@ -63,6 +84,6 @@ object-config:
                 Cat-000000: 'Cat1'
             expected:
                 Response: 'Error'
-                Message: 'File requires escalated priveledges'
+                Message: 'File requires escalated privileges'
 
 


### PR DESCRIPTION
* Added scenarios to the manager/config/restricted test to cover CreateConfig.
* Fixed the spelling of "privileges" in manager/config/restricted.
* Marked manager tests that require Lua as skipped until they can be
  rewritten.
  * action_events_response
  * authlimit
  * authtimeout