### PR TITLE
logger.conf: Include ms and line numbers in log files.

### DIFF
--- a/configs/logger.conf
+++ b/configs/logger.conf
@@ -4,10 +4,11 @@
 ; so tests have the ability to overwrite them.
 ;
 [general]
+dateformat=%F %T.%3q
 #include "logger.general.conf.inc"
 
 [logfiles]
 console => verbose
 messages.txt => notice,warning,error
-full.txt => *
+full.txt => [plain]*
 #include "logger.logfiles.conf.inc"


### PR DESCRIPTION
Make two changes to the default logger.conf used for tests, to make it significantly easier to debug failing tests:

* Include ms in log messages, rather than just seconds.
* Include line numbers in log messages, instead of just the filename.