### PR TITLE
Allow an alternate top-level test-config.yaml file to be used.

### DIFF
--- a/lib/python/asterisk/asterisk.py
+++ b/lib/python/asterisk/asterisk.py
@@ -478,6 +478,9 @@ class Asterisk(object):
         def __execute_wait_fully_booted():
             """Send the CLI command waitfullybooted"""
 
+            if self.remote_config:
+                return
+
             # try to send the command until we timeout,
             # then assume asterisk won't start and error out
             timeout = 90 if self.valgrind_enabled else 45

--- a/lib/python/asterisk/test_case.py
+++ b/lib/python/asterisk/test_case.py
@@ -120,7 +120,10 @@ class TestCase(object):
         self.passed = None
         self.fail_tokens = []
         self.timeout_id = None
-        self.global_config = TestConfig(os.getcwd())
+        if os.environ.get('TESTSUITE_CONFIG'):
+            self.global_config = TestConfig(os.environ['TESTSUITE_CONFIG'])
+        else:
+            self.global_config = TestConfig(os.getcwd())
         self.test_config = TestConfig(self.test_name, self.global_config)
         self.condition_controller = None
         self.pcap = None


### PR DESCRIPTION
A new `--testsuite-config=<yaml_file>` option has been added to runtests.py
that allows different test configurations to be used without having to
swap out the checked-in default `test-config.yaml`.  It can be used
in the following scenarios:

* Realtime tests:  The realtime tests require database connection information
be specified in the top-level test-config.yaml.  Instead of replacing it
with a modified version, you can now create a separate file, say
`test-config-realtime.yaml` and specify it with
`./runtests.py --testsuite-config=./test-config-realtime.yaml ...`

* Using a running asterisk instance:  Sometimes it's handy to run a testsuite
test against a running instance of asterisk. This requires specifying host
information in the top-level test-config.yaml. Assuming the instance is
properly configured for the test, you can now create a separate
file, say `test-config-running.yaml` and specify it with
`./runtests.py --testsuite-config=./test-config-running.yaml ...`
