### PR TITLE
rest_api: race conditions on test teardown

### DIFF
--- a/tests/rest_api/applications/subscribe-endpoint/nominal/resource/test-config.yaml
+++ b/tests/rest_api/applications/subscribe-endpoint/nominal/resource/test-config.yaml
@@ -103,28 +103,17 @@ ari-config:
                         name: 'PJSIP/bob-00000000'
                         state: Up
             count: 1
-        -   conditions:
-                match:
-                    type: ChannelDestroyed
-                    application: testsuite
-                    cause: 16
-                    cause_txt: 'Normal Clearing'
-                    channel:
-                        name: 'PJSIP/bob-00000000'
-                        state: Up
-            count: 1
 
 ari-test-stopper:
     -
         ari-events:
             match:
-                type: EndpointStateChange
+                type: ChannelDestroyed
                 application: testsuite
-                endpoint:
-                    technology: PJSIP
-                    resource: bob
-                    state: online
-                    channel_ids: []
+                cause: 16
+                cause_txt: 'Normal Clearing'
+                channel:
+                    name: 'PJSIP/bob-00000000'
         stop_test:
 
 

--- a/tests/rest_api/bridges/softmix_unhold/test-config.yaml
+++ b/tests/rest_api/bridges/softmix_unhold/test-config.yaml
@@ -123,17 +123,4 @@ event-actions:
                     Event: 'MusicOnHoldStop'
                     Uniqueid: 'alice'
             count: 1
-        ari-requests:
-            -
-                method: 'delete'
-                uri: 'channels/alice'
-            -
-                method: 'delete'
-                uri: 'channels/bob'
-            -
-                method: 'delete'
-                uri: 'channels/charlie'
-            -
-                method: 'delete'
-                uri: 'bridges/lebridge'
         stop_test:


### PR DESCRIPTION
The following tests used stop_test methods that were inconsistent
with similar tests, leading to intermittent race conditions on
test termination that could cause required events to be missed

rest_api/applications/subscribe-endpoint/nominal/resource
rest_api/bridges/softmix_unhold

This change modifies the tests to match similar tests in the same
categories.
