### PR TITLE
realtime: Address test failures in realtime_converter

### DIFF
--- a/tests/manager/bridge_actions/test-config.yaml
+++ b/tests/manager/bridge_actions/test-config.yaml
@@ -75,3 +75,4 @@ properties:
         - asterisk: 'chan_sip'
     tags:
         - bridge
+        - realtime-incompatible


### PR DESCRIPTION
First, the realtime converter was modified to use pathlib to create
parent directories for missing files.

Second, the realtime converter was modified to assume 'global' and
'system' section types in pjsip.conf if the optional type identifier
was not set for the 'global' and 'system' sections respectively.

Lastly, the tests/manager/bridge_actions test was marked as
realtime-incompatible.

Fixes: #89
