### PR TITLE
res_pjsip_diversion: re-enable unstable diversion basic test

### DIFF
--- a/tests/channels/pjsip/diversion/diversion_basic/test-config.yaml
+++ b/tests/channels/pjsip/diversion/diversion_basic/test-config.yaml
@@ -1,5 +1,4 @@
 testinfo:
-    skip: 'Unstable - issue #33'
     summary: 'Test to make sure an appropriate diversion header gets added when
               a call is forwarded.'
     description: |


### PR DESCRIPTION
Re-enabling the diversion basic test once Asterisk PR 1350 is merged as
the test should now pass consistently.
