### PR TITLE
Addressing test failures under SIPp v 3.7.5.

### DIFF
--- a/tests/channels/pjsip/basic_calls/incoming/off-nominal/md5/test-config.yaml
+++ b/tests/channels/pjsip/basic_calls/incoming/off-nominal/md5/test-config.yaml
@@ -23,28 +23,32 @@ test-object-config:
                 # IPv4 & UDP - wrong username
                 - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '127.0.0.1', '-p': '5062', '-au': 'carol', '-ap': 'swordfish', '-inf': 'credentials-wrong_user.csv'} }
                 # IPv4 & UDP - wrong realm
-                - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '127.0.0.1', '-p': '5063', '-au': 'alice', '-ap': 'swordfish', '-inf': 'credentials-wrong_realm.csv'} }
+                # Disabled due to SIPp limitations as [authentication] cannot be used outside of a message
+                #- { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '127.0.0.1', '-p': '5063', '-au': 'alice', '-ap': 'swordfish', '-inf': 'credentials-wrong_realm.csv'} }
 
                 # IPv4 & TCP - wrong password
                 - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '127.0.0.1', '-p': '5064', '-au': 'alice', '-ap': 'halibut', '-inf': 'credentials-wrong_pass.csv', '-t': 't1'} }
                 # IPv4 & TCP - wrong username
                 - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '127.0.0.1', '-p': '5065', '-au': 'carol', '-ap': 'swordfish', '-inf': 'credentials-wrong_user.csv', '-t': 't1'} }
                 # IPv4 & TCP - wrong realm
-                - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '127.0.0.1', '-p': '5066', '-au': 'alice', '-ap': 'swordfish', '-inf': 'credentials-wrong_realm.csv', '-t': 't1'} }
+                # Disabled due to SIPp limitations as [authentication] cannot be used outside of a message
+                #- { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '127.0.0.1', '-p': '5066', '-au': 'alice', '-ap': 'swordfish', '-inf': 'credentials-wrong_realm.csv', '-t': 't1'} }
 
                 # IPv6 & UDP - wrong password
-                - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5067', '-au': 'alice', '-ap': 'halibut', '-inf': 'credentials-wrong_pass.csv'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '[::1]', '-p': '5067', '-au': 'alice', '-ap': 'halibut', '-inf': 'credentials-wrong_pass.csv'} }
                 # IPv6 & UDP - wrong username
-                - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5068', '-au': 'carol', '-ap': 'swordfish', '-inf': 'credentials-wrong_user.csv'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '[::1]', '-p': '5068', '-au': 'carol', '-ap': 'swordfish', '-inf': 'credentials-wrong_user.csv'} }
                 # IPv6 & UDP - wrong realm
-                - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5069', '-au': 'alice', '-ap': 'swordfish', '-inf': 'credentials-wrong_realm.csv'} }
+                # Disabled due to SIPp limitations as [authentication] cannot be used outside of a message
+                #- { 'target': '[::1]', 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '[::1]', '-p': '5069', '-au': 'alice', '-ap': 'swordfish', '-inf': 'credentials-wrong_realm.csv'} }
 
                 # IPv6 & TCP - wrong password
-                - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5070', '-au': 'alice', '-ap': 'halibut', '-inf': 'credentials-wrong_pass.csv', '-t': 't1'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '[::1]', '-p': '5070', '-au': 'alice', '-ap': 'halibut', '-inf': 'credentials-wrong_pass.csv', '-t': 't1'} }
                 # IPv6 & TCP - wrong username
-                - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5071', '-au': 'carol', '-ap': 'swordfish', '-inf': 'credentials-wrong_user.csv', '-t': 't1'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '[::1]', '-p': '5071', '-au': 'carol', '-ap': 'swordfish', '-inf': 'credentials-wrong_user.csv', '-t': 't1'} }
                 # IPv6 & TCP - wrong realm
-                - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5072', '-au': 'alice', '-ap': 'swordfish', '-inf': 'credentials-wrong_realm.csv', '-t': 't1'} }
+                # Disabled due to SIPp limitations as [authentication] cannot be used outside of a message
+                #- { 'target': '[::1]', 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '[::1]', '-p': '5072', '-au': 'alice', '-ap': 'swordfish', '-inf': 'credentials-wrong_realm.csv', '-t': 't1'} }
 
 properties:
     dependencies:

--- a/tests/channels/pjsip/basic_calls/incoming/off-nominal/userpass/wrong_credentials/test-config.yaml
+++ b/tests/channels/pjsip/basic_calls/incoming/off-nominal/userpass/wrong_credentials/test-config.yaml
@@ -23,28 +23,32 @@ test-object-config:
                 # IPv4 & UDP - wrong username
                 - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '127.0.0.1', '-p': '5062', '-au': 'carol', '-ap': 'swordfish', '-inf': 'credentials-wrong_user.csv'} }
                 # IPv4 & UDP - wrong realm
-                - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '127.0.0.1', '-p': '5063', '-au': 'alice', '-ap': 'swordfish', '-inf': 'credentials-wrong_realm.csv'} }
+                # Disabled due to SIPp limitations as [authentication] cannot be used outside of a message
+                #- { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '127.0.0.1', '-p': '5063', '-au': 'alice', '-ap': 'swordfish', '-inf': 'credentials-wrong_realm.csv'} }
 
                 # IPv4 & TCP - wrong password
                 - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '127.0.0.1', '-p': '5064', '-au': 'alice', '-ap': 'halibut', '-inf': 'credentials-wrong_pass.csv', '-t': 't1'} }
                 # IPv4 & TCP - wrong username
                 - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '127.0.0.1', '-p': '5065', '-au': 'carol', '-ap': 'swordfish', '-inf': 'credentials-wrong_user.csv', '-t': 't1'} }
                 # IPv4 & TCP - wrong realm
-                - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '127.0.0.1', '-p': '5066', '-au': 'alice', '-ap': 'swordfish', '-inf': 'credentials-wrong_realm.csv', '-t': 't1'} }
+                # Disabled due to SIPp limitations as [authentication] cannot be used outside of a message
+                #- { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '127.0.0.1', '-p': '5066', '-au': 'alice', '-ap': 'swordfish', '-inf': 'credentials-wrong_realm.csv', '-t': 't1'} }
 
                 # IPv6 & UDP - wrong password
-                - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5067', '-au': 'alice', '-ap': 'halibut', '-inf': 'credentials-wrong_pass.csv'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '[::1]', '-p': '5067', '-au': 'alice', '-ap': 'halibut', '-inf': 'credentials-wrong_pass.csv'} }
                 # IPv6 & UDP - wrong username
-                - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5068', '-au': 'carol', '-ap': 'swordfish', '-inf': 'credentials-wrong_user.csv'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '[::1]', '-p': '5068', '-au': 'carol', '-ap': 'swordfish', '-inf': 'credentials-wrong_user.csv'} }
                 # IPv6 & UDP - wrong realm
-                - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5069', '-au': 'alice', '-ap': 'swordfish', '-inf': 'credentials-wrong_realm.csv'} }
+                # Disabled due to SIPp limitations as [authentication] cannot be used outside of a message
+                #- { 'target': '[::1]', 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '[::1]', '-p': '5069', '-au': 'alice', '-ap': 'swordfish', '-inf': 'credentials-wrong_realm.csv'} }
 
                 # IPv6 & TCP - wrong password
-                - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5070', '-au': 'alice', '-ap': 'halibut', '-inf': 'credentials-wrong_pass.csv', '-t': 't1'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '[::1]', '-p': '5070', '-au': 'alice', '-ap': 'halibut', '-inf': 'credentials-wrong_pass.csv', '-t': 't1'} }
                 # IPv6 & TCP - wrong username
-                - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5071', '-au': 'carol', '-ap': 'swordfish', '-inf': 'credentials-wrong_user.csv', '-t': 't1'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '[::1]', '-p': '5071', '-au': 'carol', '-ap': 'swordfish', '-inf': 'credentials-wrong_user.csv', '-t': 't1'} }
                 # IPv6 & TCP - wrong realm
-                - { 'key-args': {'scenario': 'playback_with_initial_sdp.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5072', '-au': 'alice', '-ap': 'swordfish', '-inf': 'credentials-wrong_realm.csv', '-t': 't1'} }
+                # Disabled due to SIPp limitations as [authentication] cannot be used outside of a message
+                #- { 'target': '[::1]', 'key-args': {'scenario': 'playback_with_initial_sdp.xml', '-i': '[::1]', '-p': '5072', '-au': 'alice', '-ap': 'swordfish', '-inf': 'credentials-wrong_realm.csv', '-t': 't1'} }
 
 properties:
     dependencies:

--- a/tests/channels/pjsip/basic_calls/outgoing/off-nominal/bob_does_not_exist/test-config.yaml
+++ b/tests/channels/pjsip/basic_calls/outgoing/off-nominal/bob_does_not_exist/test-config.yaml
@@ -33,10 +33,10 @@ test-object-config:
    test-iterations:
        -
            scenarios:
-               - { 'key-args': {'scenario': 'receive.xml', '-i': '127.0.0.1', '-p': '5062', '-s': 'bob-ipv4-udp'}, 'ordered-args': ['-enable-retrans'] }
-               - { 'key-args': {'scenario': 'receive.xml', '-i': '127.0.0.1', '-p': '5063', '-t': 't1', '-s': 'bob-ipv4-tcp'} }
-               - { 'target': '[::1]', 'key-args': {'scenario': 'receive.xml', '-i': '[::1]', '-p': '5064', '-s': 'bob-ipv6-udp'}, 'ordered-args': ['-enable-retrans'] }
-               - { 'target': '[::1]', 'key-args': {'scenario': 'receive.xml', '-i': '[::1]', '-p': '5065', '-t': 't1', '-s': 'bob-ipv6-tcp'} }
+               - { 'key-args': {'scenario': 'receive.xml', '-i': '127.0.0.1', '-p': '5062', '-s': 'bob-ipv4-udp', '-timeout': '30000'}, 'ordered-args': ['-enable-retrans'] }
+               - { 'key-args': {'scenario': 'receive.xml', '-i': '127.0.0.1', '-p': '5063', '-t': 't1', '-s': 'bob-ipv4-tcp', '-timeout': '30000'} }
+               - { 'target': '[::1]', 'key-args': {'scenario': 'receive.xml', '-i': '[::1]', '-p': '5064', '-s': 'bob-ipv6-udp', '-timeout': '30000'}, 'ordered-args': ['-enable-retrans'] }
+               - { 'target': '[::1]', 'key-args': {'scenario': 'receive.xml', '-i': '[::1]', '-p': '5065', '-t': 't1', '-s': 'bob-ipv6-tcp', '-timeout': '30000'} }
 
 originator-config-ipv4-udp:
     trigger: 'scenario_start'

--- a/tests/channels/pjsip/non_negotiated_frame_SSRC_change/test-config.yaml
+++ b/tests/channels/pjsip/non_negotiated_frame_SSRC_change/test-config.yaml
@@ -20,8 +20,8 @@ test-object-config:
     test-iterations:
         -
             scenarios:
-                - { 'key-args': { 'scenario': 'uas_asterisk.xml', '-i': '127.0.0.1', '-p': '5700'} }
-                - { 'key-args': { 'scenario': 'uac_g719_g711.xml', '-i': '127.0.0.1', '-p': '5061', '-s': '3200000000', '-d': '20000', '-mp': '6000'} }
+                - { 'key-args': { 'scenario': 'uas_asterisk.xml', '-i': '127.0.0.1', '-p': '5700', '-timeout': '30000'} }
+                - { 'key-args': { 'scenario': 'uac_g719_g711.xml', '-i': '127.0.0.1', '-p': '5061', '-s': '3200000000', '-d': '20000', '-mp': '6000', '-timeout': '30000'} }
 
 properties:
     dependencies:

--- a/tests/channels/pjsip/registration/inbound/nominal/config_options/maximum_expiration/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/nominal/config_options/maximum_expiration/test-config.yaml
@@ -30,10 +30,10 @@ test-object-config:
                 - { 'key-args': {'scenario': 'register-noauth.xml', '-i': '127.0.0.1', '-p': '5062', '-t': 't1', '-s': 'bob'} }
 
                 # IPv6 & UDP
-                - { 'key-args': {'scenario': 'register-noauth.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5063', '-s': 'charlie'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth.xml', '-i': '[::1]', '-p': '5063', '-s': 'charlie'} }
 
                 # IPv6 & TCP
-                - { 'key-args': {'scenario': 'register-noauth.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5064', '-t': 't1', '-s': 'carol'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth.xml', '-i': '[::1]', '-p': '5064', '-t': 't1', '-s': 'carol'} }
 
 ami-config:
     -

--- a/tests/channels/pjsip/registration/inbound/nominal/config_options/minimum_expiration/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/nominal/config_options/minimum_expiration/test-config.yaml
@@ -30,10 +30,10 @@ test-object-config:
                 - { 'key-args': {'scenario': 'register-noauth.xml', '-i': '127.0.0.1', '-p': '5062', '-t': 't1', '-s': 'bob'} }
 
                 # IPv6 & UDP
-                - { 'key-args': {'scenario': 'register-noauth.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5063', '-s': 'charlie'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth.xml', '-i': '[::1]', '-p': '5063', '-s': 'charlie'} }
 
                 # IPv6 & TCP
-                - { 'key-args': {'scenario': 'register-noauth.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5064', '-t': 't1', '-s': 'carol'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth.xml', '-i': '[::1]', '-p': '5064', '-t': 't1', '-s': 'carol'} }
 
 ami-config:
     -

--- a/tests/channels/pjsip/registration/inbound/nominal/config_options/remove_existing/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/nominal/config_options/remove_existing/test-config.yaml
@@ -47,16 +47,16 @@ test-object-config-v13.18.0:
                 # IPv4 & TCP
                 - { 'key-args': {'scenario': 'register-v13.18-ipv4.xml', '-i': '127.0.0.1', '-p': '5061', '-t': 't1', '-s': 'bob'} }
                 # IPv6 & UDP
-                - { 'key-args': {'scenario': 'register-v13.18-ipv6.xml',
-                                 'target': '[::1]', '-i': '[::1]', '-p': '5061', '-s': 'charlie'},
+                - { 'target': '[::1]',
+                    'key-args': {'scenario': 'register-v13.18-ipv6.xml', '-i': '[::1]', '-p': '5061', '-s': 'charlie'},
                     'ordered-args': ['-key', 'customip1', '[::2]', '-key', 'customip2', '[::3]',
                                      '-key', 'customip3', '[::4]', '-key', 'customip4', '[::5]',
                                      '-key', 'customip5', '[::6]', '-key', 'customip6', '[::7]',
                                      '-key', 'customip7', '[::8]', '-key', 'customip8', '[::9]',
                                      '-key', 'customip9', '[::10]'] }
                 # IPv6 & TCP
-                - { 'key-args': {'scenario': 'register-v13.18-ipv6.xml',
-                                 'target': '[::1]', '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'carol'},
+                - { 'target': '[::1]',
+                    'key-args': {'scenario': 'register-v13.18-ipv6.xml', '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'carol'},
                     'ordered-args': ['-key', 'customip1', '[::2]', '-key', 'customip2', '[::3]',
                                      '-key', 'customip3', '[::4]', '-key', 'customip4', '[::5]',
                                      '-key', 'customip5', '[::6]', '-key', 'customip6', '[::7]',

--- a/tests/channels/pjsip/registration/inbound/nominal/mixed/unauthed/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/nominal/mixed/unauthed/test-config.yaml
@@ -31,13 +31,15 @@ test-object-config:
                                     '-i': '127.0.0.1', '-p': '5061', '-t': 't1', '-s': 'bob'} }
 
                 # IPv6 & UDP - register with no authentication
-                - { 'key-args': {'scenario': 'mixed-noauth-contact-expiry-ipv6.xml',
-                                    'target': '[::1]', '-i': '[::1]', '-p': '5061', '-s': 'charlie'},
+                - { 'target': '[::1]',
+                    'key-args': {'scenario': 'mixed-noauth-contact-expiry-ipv6.xml',
+                                   '-i': '[::1]', '-p': '5061', '-s': 'charlie'},
                     'ordered-args': ['-key', 'customip1', '[::2]', '-key', 'customip2', '[::3]'] }
 
                 # IPv6 & TCP - register with no authentication
-                - { 'key-args': {'scenario': 'mixed-noauth-contact-expiry-ipv6.xml',
-                                    'target': '[::1]', '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'carol'},
+                - { 'target': '[::1]',
+                    'key-args': {'scenario': 'mixed-noauth-contact-expiry-ipv6.xml',
+                                   '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'carol'},
                     'ordered-args': ['-key', 'customip1', '[::2]', '-key', 'customip2', '[::3]'] }
 
 ami-config:

--- a/tests/channels/pjsip/registration/inbound/nominal/multiple_contacts/authed/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/nominal/multiple_contacts/authed/test-config.yaml
@@ -26,23 +26,25 @@ test-object-config:
                 # IPv4 & UDP - register with authentication
                 - { 'key-args': {'scenario': 'register-auth-multi-contact-expiry-ipv4.xml',
                                     '-i': '127.0.0.1', '-p': '5061', '-s': 'alice',
-                                    '-au': 'alice', '-ap': 'swordfish'} }
+                                    '-au': 'alice', '-ap': 'swordfish', '-timeout': '40000'} }
 
                 # IPv4 & TCP - register with authentication
                 - { 'key-args': {'scenario': 'register-auth-multi-contact-expiry-ipv4.xml',
                                     '-i': '127.0.0.1', '-p': '5061', '-t': 't1', '-s': 'bob',
-                                    '-au': 'bob', '-ap': 'swordfish'} }
+                                    '-au': 'bob', '-ap': 'swordfish', '-timeout': '40000'} }
 
                 # IPv6 & UDP - register with authentication
-                - { 'key-args': {'scenario': 'register-auth-multi-contact-expiry-ipv6.xml',
-                                    'target': '[::1]', '-i': '[::1]', '-p': '5061', '-s': 'charlie',
-                                    '-au': 'charlie', '-ap': 'swordfish'},
+                - { 'target': '[::1]',
+                    'key-args': {'scenario': 'register-auth-multi-contact-expiry-ipv6.xml',
+                                    '-i': '[::1]', '-p': '5061', '-s': 'charlie',
+                                    '-au': 'charlie', '-ap': 'swordfish', '-timeout': '40000'},
                     'ordered-args': ['-key', 'customip1', '[::2]', '-key', 'customip2', '[::3]'] }
 
                 # IPv6 & TCP - register with authentication
-                - { 'key-args': {'scenario': 'register-auth-multi-contact-expiry-ipv6.xml',
-                                    'target': '[::1]', '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'carol',
-                                    '-au': 'carol', '-ap': 'swordfish'},
+                - { 'target': '[::1]',
+                    'key-args': {'scenario': 'register-auth-multi-contact-expiry-ipv6.xml',
+                                    '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'carol',
+                                    '-au': 'carol', '-ap': 'swordfish', '-timeout': '40000'},
                     'ordered-args': ['-key', 'customip1', '[::2]', '-key', 'customip2', '[::3]'] }
 
 ami-config:

--- a/tests/channels/pjsip/registration/inbound/nominal/multiple_contacts/unauthed/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/nominal/multiple_contacts/unauthed/test-config.yaml
@@ -30,13 +30,15 @@ test-object-config:
                                     '-i': '127.0.0.1', '-p': '5061', '-t': 't1', '-s': 'bob'} }
 
                 # IPv6 & UDP - register with no authentication
-                - { 'key-args': {'scenario': 'register-noauth-multi-contact-expiry-ipv6.xml',
-                                    'target': '[::1]', '-i': '[::1]', '-p': '5061', '-s': 'charlie'},
+                - { 'target': '[::1]',
+                    'key-args': {'scenario': 'register-noauth-multi-contact-expiry-ipv6.xml',
+                                    '-i': '[::1]', '-p': '5061', '-s': 'charlie'},
                     'ordered-args': ['-key', 'customip1', '[::2]', '-key', 'customip2', '[::3]'] }
 
                 # IPv6 & TCP - register with no authentication
-                - { 'key-args': {'scenario': 'register-noauth-multi-contact-expiry-ipv6.xml',
-                                    'target': '[::1]', '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'carol'},
+                - { 'target': '[::1]',
+                    'key-args': {'scenario': 'register-noauth-multi-contact-expiry-ipv6.xml',
+                                    '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'carol'},
                     'ordered-args': ['-key', 'customip1', '[::2]', '-key', 'customip2', '[::3]'] }
 
 ami-config:

--- a/tests/channels/pjsip/registration/inbound/nominal/multiple_contacts/unauthed_drop_options/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/nominal/multiple_contacts/unauthed_drop_options/test-config.yaml
@@ -30,13 +30,15 @@ test-object-config:
                                     '-i': '127.0.0.1', '-p': '5061', '-t': 't1', '-s': 'bob'} }
 
                 # IPv6 & UDP - register with no authentication
-                - { 'key-args': {'scenario': 'register-noauth-multi-contact-expiry-ipv6.xml',
-                                    'target': '[::1]', '-i': '[::1]', '-p': '5061', '-s': 'charlie'},
+                - { 'target': '[::1]',
+                    'key-args': {'scenario': 'register-noauth-multi-contact-expiry-ipv6.xml',
+                                   '-i': '[::1]', '-p': '5061', '-s': 'charlie'},
                     'ordered-args': ['-key', 'customip1', '[::2]', '-key', 'customip2', '[::3]'] }
 
                 # IPv6 & TCP - register with no authentication
-                - { 'key-args': {'scenario': 'register-noauth-multi-contact-expiry-ipv6.xml',
-                                    'target': '[::1]', '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'carol'},
+                - { 'target': '[::1]',
+                    'key-args': {'scenario': 'register-noauth-multi-contact-expiry-ipv6.xml',
+                                   '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'carol'},
                     'ordered-args': ['-key', 'customip1', '[::2]', '-key', 'customip2', '[::3]'] }
 
 ami-config:

--- a/tests/channels/pjsip/registration/inbound/nominal/single_contact/authed/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/nominal/single_contact/authed/test-config.yaml
@@ -27,10 +27,10 @@ test-object-config:
                 - { 'key-args': {'scenario': 'register-auth.xml', '-i': '127.0.0.1', '-p': '5062', '-t': 't1', '-s': 'bob', '-au': 'bob', '-ap': 'swordfish'} }
 
                 # IPv6 & UDP - register with authentication
-                - { 'key-args': {'scenario': 'register-auth.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5063', '-s': 'charlie', '-au': 'charlie', '-ap': 'swordfish'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-auth.xml', '-i': '[::1]', '-p': '5063', '-s': 'charlie', '-au': 'charlie', '-ap': 'swordfish'} }
 
                 # IPv6 & TCP - register with authentication
-                - { 'key-args': {'scenario': 'register-auth.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5064', '-t': 't1', '-s': 'carol', '-au': 'carol', '-ap': 'swordfish'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-auth.xml', '-i': '[::1]', '-p': '5064', '-t': 't1', '-s': 'carol', '-au': 'carol', '-ap': 'swordfish'} }
 
 ami-config:
     -

--- a/tests/channels/pjsip/registration/inbound/nominal/single_contact/unauthed/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/nominal/single_contact/unauthed/test-config.yaml
@@ -27,10 +27,10 @@ test-object-config:
                 - { 'key-args': {'scenario': 'register-noauth.xml', '-i': '127.0.0.1', '-p': '5062', '-t': 't1', '-s': 'bob'} }
 
                 # IPv6 & UDP - register with no authentication
-                - { 'key-args': {'scenario': 'register-noauth.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5063', '-s': 'charlie'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth.xml', '-i': '[::1]', '-p': '5063', '-s': 'charlie'} }
 
                 # IPv6 & TCP - register with no authentication
-                - { 'key-args': {'scenario': 'register-noauth.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5064', '-t': 't1', '-s': 'carol'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth.xml', '-i': '[::1]', '-p': '5064', '-t': 't1', '-s': 'carol'} }
 
 ami-config:
     -

--- a/tests/channels/pjsip/registration/inbound/nominal/single_contact/unauthed_drop_options/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/nominal/single_contact/unauthed_drop_options/test-config.yaml
@@ -27,10 +27,10 @@ test-object-config:
                 - { 'key-args': {'scenario': 'register-noauth.xml', '-i': '127.0.0.1', '-p': '5062', '-t': 't1', '-s': 'bob'} }
 
                 # IPv6 & UDP - register with no authentication
-                - { 'key-args': {'scenario': 'register-noauth.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5063', '-s': 'charlie'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth.xml', '-i': '[::1]', '-p': '5063', '-s': 'charlie'} }
 
                 # IPv6 & TCP - register with no authentication
-                - { 'key-args': {'scenario': 'register-noauth.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5064', '-t': 't1', '-s': 'carol'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth.xml', '-i': '[::1]', '-p': '5064', '-t': 't1', '-s': 'carol'} }
 
 ami-config:
     -

--- a/tests/channels/pjsip/registration/inbound/nominal/unregister/all_contacts/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/nominal/unregister/all_contacts/test-config.yaml
@@ -31,12 +31,12 @@ test-object-config:
                                     '-p': '5061', '-t': 't1', '-s': 'bob'} }
 
                 # IPv6 & UDP
-                - { 'key-args': {'scenario': 'register-noauth-ipv6.xml', 'target': '[::1]',
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth-ipv6.xml',
                                     '-i': '[::1]', '-p': '5061', '-s': 'charlie'},
                     'ordered-args': ['-key', 'customip1', '[::2]', '-key', 'customip2', '[::3]'] }
 
                 # IPv6 & TCP
-                - { 'key-args': {'scenario': 'register-noauth-ipv6.xml', 'target': '[::1]',
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth-ipv6.xml',
                                     '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'carol'},
                     'ordered-args': ['-key', 'customip1', '[::2]', '-key', 'customip2', '[::3]'] }
 

--- a/tests/channels/pjsip/registration/inbound/nominal/unregister/multiple_contacts/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/nominal/unregister/multiple_contacts/test-config.yaml
@@ -32,12 +32,12 @@ test-object-config:
                                     '-p': '5061', '-t': 't1', '-s': 'bob'} }
 
                 # IPv6 & UDP
-                - { 'key-args': {'scenario': 'register-noauth-ipv6.xml', 'target': '[::1]',
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth-ipv6.xml',
                                     '-i': '[::1]', '-p': '5061', '-s': 'charlie'},
                     'ordered-args': ['-key', 'customip1', '[::2]', '-key', 'customip2', '[::3]'] }
 
                 # IPv6 & TCP
-                - { 'key-args': {'scenario': 'register-noauth-ipv6.xml', 'target': '[::1]',
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth-ipv6.xml',
                                     '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'carol'},
                     'ordered-args': ['-key', 'customip1', '[::2]', '-key', 'customip2', '[::3]'] }
 

--- a/tests/channels/pjsip/registration/inbound/nominal/unregister/single_contact/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/nominal/unregister/single_contact/test-config.yaml
@@ -28,10 +28,10 @@ test-object-config:
                 - { 'key-args': {'scenario': 'register-noauth.xml', '-i': '127.0.0.1', '-p': '5062', '-t': 't1', '-s': 'bob'} }
 
                 # IPv6 & UDP
-                - { 'key-args': {'scenario': 'register-noauth.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5063', '-s': 'charlie'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth.xml', '-i': '[::1]', '-p': '5063', '-s': 'charlie'} }
 
                 # IPv6 & TCP
-                - { 'key-args': {'scenario': 'register-noauth.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5064', '-t': 't1', '-s': 'carol'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth.xml', '-i': '[::1]', '-p': '5064', '-t': 't1', '-s': 'carol'} }
 
 ami-config:
     -

--- a/tests/channels/pjsip/registration/inbound/off-nominal/max_contacts/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/off-nominal/max_contacts/test-config.yaml
@@ -24,10 +24,10 @@ test-object-config:
                 - { 'key-args': {'scenario': 'register-too-many-contacts.xml', '-i': '127.0.0.1', '-p': '5061', '-t': 't1', '-s': 'alice'} }
 
                 # IPv6 & UDP - register with no contact header
-                - { 'key-args': {'scenario': 'register-too-many-contacts.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5061', '-s': 'alice'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-too-many-contacts.xml', '-i': '[::1]', '-p': '5061', '-s': 'alice'} }
 
                 # IPv6 & TCP - register with no contact header
-                - { 'key-args': {'scenario': 'register-too-many-contacts.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'alice'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-too-many-contacts.xml', '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'alice'} }
 
 properties:
     dependencies:

--- a/tests/channels/pjsip/registration/inbound/off-nominal/no_contact_header/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/off-nominal/no_contact_header/test-config.yaml
@@ -25,10 +25,10 @@ test-object-config:
                 - { 'key-args': {'scenario': 'register-noauth-no-contact-header.xml', '-i': '127.0.0.1', '-p': '5061', '-t': 't1', '-s': 'alice'} }
 
                 # IPv6 & UDP - register with no contact header
-                - { 'key-args': {'scenario': 'register-noauth-no-contact-header.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5061', '-s': 'alice'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth-no-contact-header.xml', '-i': '[::1]', '-p': '5061', '-s': 'alice'} }
 
                 # IPv6 & TCP - register with no contact header
-                - { 'key-args': {'scenario': 'register-noauth-no-contact-header.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'alice'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth-no-contact-header.xml', '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'alice'} }
 
 properties:
     dependencies:

--- a/tests/channels/pjsip/registration/inbound/off-nominal/unregister/no_expires_header/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/off-nominal/unregister/no_expires_header/test-config.yaml
@@ -29,10 +29,10 @@ test-object-config:
                 - { 'key-args': {'scenario': 'register-noauth.xml', '-i': '127.0.0.1', '-p': '5062', '-t': 't1', '-s': 'bob'} }
 
                 # IPv6 & UDP
-                - { 'key-args': {'scenario': 'register-noauth.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5063', '-s': 'charlie'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth.xml', '-i': '[::1]', '-p': '5063', '-s': 'charlie'} }
 
                 # IPv6 & TCP
-                - { 'key-args': {'scenario': 'register-noauth.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5064', '-t': 't1', '-s': 'carol'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-noauth.xml', '-i': '[::1]', '-p': '5064', '-t': 't1', '-s': 'carol'} }
 
 ami-config:
     -

--- a/tests/channels/pjsip/registration/inbound/off-nominal/wrong_password/test-config.yaml
+++ b/tests/channels/pjsip/registration/inbound/off-nominal/wrong_password/test-config.yaml
@@ -24,10 +24,10 @@ test-object-config:
                 - { 'key-args': {'scenario': 'register-wrong-password.xml', '-i': '127.0.0.1', '-p': '5061', '-t': 't1', '-s': 'alice', '-au': 'alice', '-ap': 'wrong'} }
 
                 # IPv6 & UDP - register attempt with wrong password
-                - { 'key-args': {'scenario': 'register-wrong-password.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5061', '-s': 'alice', '-au': 'alice', '-ap': 'wrong'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-wrong-password.xml', '-i': '[::1]', '-p': '5061', '-s': 'alice', '-au': 'alice', '-ap': 'wrong'} }
 
                 # IPv6 & TCP - register attempt with wrong password
-                - { 'key-args': {'scenario': 'register-wrong-password.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'alice', '-au': 'alice', '-ap': 'wrong'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-wrong-password.xml', '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'alice', '-au': 'alice', '-ap': 'wrong'} }
         -
             scenarios:
                 # IPv4 & UDP - register attempt with no password
@@ -37,10 +37,10 @@ test-object-config:
                 - { 'key-args': {'scenario': 'register-wrong-password.xml', '-i': '127.0.0.1', '-p': '5061', '-t': 't1', '-s': 'alice', '-au': 'alice'} }
 
                 # IPv6 & UDP - register attempt with no password
-                - { 'key-args': {'scenario': 'register-wrong-password.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5061', '-s': 'alice', '-au': 'alice'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-wrong-password.xml', '-i': '[::1]', '-p': '5061', '-s': 'alice', '-au': 'alice'} }
 
                 # IPv6 & TCP - register attempt with no password
-                - { 'key-args': {'scenario': 'register-wrong-password.xml', 'target': '[::1]', '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'alice', '-au': 'alice'} }
+                - { 'target': '[::1]', 'key-args': {'scenario': 'register-wrong-password.xml', '-i': '[::1]', '-p': '5061', '-t': 't1', '-s': 'alice', '-au': 'alice'} }
 
 properties:
     dependencies:

--- a/tests/channels/pjsip/registration/outbound/fatal_retry/test-config.yaml
+++ b/tests/channels/pjsip/registration/outbound/fatal_retry/test-config.yaml
@@ -14,8 +14,8 @@ test-object-config:
     test-iterations:
         -
             scenarios:
-                - { 'key-args': { 'scenario': 'register-retry.xml', '-p': '5065' } }
-                - { 'key-args': { 'scenario': 'register-no-retry.xml', '-p': '5066' } }
+                - { 'key-args': { 'scenario': 'register-retry.xml', '-p': '5065', '-timeout': '30000' } }
+                - { 'key-args': { 'scenario': 'register-no-retry.xml', '-p': '5066', '-timeout': '30000' } }
 
 properties:
     dependencies:

--- a/tests/channels/pjsip/registration/outbound/forbidden_retry/test-config.yaml
+++ b/tests/channels/pjsip/registration/outbound/forbidden_retry/test-config.yaml
@@ -17,8 +17,8 @@ test-object-config:
     test-iterations:
         -
             scenarios:
-                - { 'key-args': { 'scenario': 'register-retry.xml', '-p': '5065' } }
-                - { 'key-args': { 'scenario': 'register-no-retry.xml', '-p': '5066' } }
+                - { 'key-args': { 'scenario': 'register-retry.xml', '-p': '5065', '-timeout': '30000' } }
+                - { 'key-args': { 'scenario': 'register-no-retry.xml', '-p': '5066', '-timeout': '30000' } }
 
 properties:
     dependencies:

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local/sipp/referee.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local/sipp/referee.xml
@@ -117,6 +117,13 @@
     ]]>
   </send>
 
+  <!-- send an empty command to the referer signaling it to complete -->
+  <sendCmd>
+    <![CDATA[
+      Call-ID: [$original_callid]
+    ]]>
+  </sendCmd>
+
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
 

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local/sipp/referer_uas.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local/sipp/referer_uas.xml
@@ -208,7 +208,10 @@
     ]]>
   </send>
 
-  <recv response="200"/>
+  <recv response="200" optional="true" />
+
+  <!-- wait for referee scenario to finish -->
+  <recvCmd />
 
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local_blonde/sipp/referee.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local_blonde/sipp/referee.xml
@@ -102,6 +102,13 @@
     ]]>
   </send>
 
+  <!-- send an empty command to the referer signaling it to complete -->
+  <sendCmd>
+    <![CDATA[
+      Call-ID: [$original_callid]
+    ]]>
+  </sendCmd>
+
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
 

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local_blonde/sipp/referer_uas.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local_blonde/sipp/referer_uas.xml
@@ -207,6 +207,11 @@
     ]]>
   </send>
 
+  <recv response="200" rtd="true" crlf="true" />
+
+  <!-- wait for referee scenario to finish -->
+  <recvCmd />
+
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
 

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local_semi_attended_transfer_record_route/sipp/referee.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local_semi_attended_transfer_record_route/sipp/referee.xml
@@ -111,6 +111,13 @@
 		]]>
 	</send>
 
+	<!-- send an empty command to the referer signaling it to complete -->
+	<sendCmd>
+		<![CDATA[
+			Call-ID: [$original_callid]
+		]]>
+	</sendCmd>
+
 	<!-- definition of the response time repartition table (unit is ms)	-->
 	<ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
 

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local_semi_attended_transfer_record_route/sipp/referer_uas.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local_semi_attended_transfer_record_route/sipp/referer_uas.xml
@@ -225,6 +225,12 @@
 		]]>
 	</send>
 
+
+	<recv response="200" rtd="true" crlf="true" optional="true" />
+
+	<!-- wait for referee scenario to finish -->
+	<recvCmd />
+
 	<!-- definition of the response time repartition table (unit is ms)	-->
 	<ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
 

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local/sipp/referee.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local/sipp/referee.xml
@@ -117,6 +117,13 @@
     ]]>
   </send>
 
+  <!-- send an empty command to the referer signaling it to complete -->
+  <sendCmd>
+    <![CDATA[
+      Call-ID: [$original_callid]
+    ]]>
+  </sendCmd>
+
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
 

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local/sipp/referer.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local/sipp/referer.xml
@@ -219,7 +219,10 @@
     ]]>
   </send>
 
-  <recv response="200"/>
+  <recv response="200" optional="true" />
+
+  <!-- wait for referee scenario to finish -->
+  <recvCmd />
 
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/sipp/referee.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/sipp/referee.xml
@@ -102,6 +102,14 @@
     ]]>
   </send>
 
+
+  <!-- send an empty command to the referer signaling it to complete -->
+  <sendCmd>
+    <![CDATA[
+        Call-ID: [$original_callid]
+    ]]>
+  </sendCmd>
+
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
 

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/sipp/referer.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/sipp/referer.xml
@@ -218,6 +218,15 @@
     ]]>
   </send>
 
+  <recv response="481" optional="true" next="done"/>
+
+  <recv response="200" rtd="true" crlf="true" optional="true" />
+
+  <label id="done"/>
+
+  <!-- wait for referee scenario to finish -->
+  <recvCmd />
+
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
 

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_remote/sipp/referee.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_remote/sipp/referee.xml
@@ -117,6 +117,9 @@
     ]]>
   </send>
 
+  <!-- wait for referer scenario to finish -->
+  <recvCmd />
+
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
 

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_remote/sipp/referer.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_remote/sipp/referer.xml
@@ -274,7 +274,14 @@
     ]]>
   </send>
 
-  <recv response="200"/>
+  <recv response="200" />
+
+  <!-- send an empty command to the referee signaling it to complete -->
+  <sendCmd>
+    <![CDATA[
+      Call-ID: REMOTE[call_id]
+    ]]>
+  </sendCmd>
 
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_remote/test-config.yaml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_remote/test-config.yaml
@@ -48,8 +48,8 @@ sipp-config:
     test-iterations:
         -
             scenarios:
-                - { 'coordinated-sender': {'key-args': {'scenario':'referer.xml', '-i': '127.0.0.3', '-p':'5060', '-sleep': '2'}, 'target':'127.0.0.1'},
-                    'coordinated-receiver': {'key-args': {'scenario':'referee.xml', '-i': '127.0.0.3', '-p':'5062'}, 'target':'127.0.0.2' } }
+                - { 'coordinated-sender': {'key-args': {'scenario':'referer.xml', '-i': '127.0.0.3', '-p':'5060', '-sleep': '2', '-timeout': '30000'}, 'target':'127.0.0.1'},
+                    'coordinated-receiver': {'key-args': {'scenario':'referee.xml', '-i': '127.0.0.3', '-p':'5062', '-timeout': '30000'}, 'target':'127.0.0.2' } }
 
 hangup-config:
     ids: [ '0', '1' ]

--- a/tests/fax/pjsip/t38_fast_reject/run-test
+++ b/tests/fax/pjsip/t38_fast_reject/run-test
@@ -55,7 +55,7 @@ def main():
     if not test.passed:
         return 1
 
-    ret_A = subprocess.call([WORKING_DIR + "/check_reinvite_rtt.py", sippA_statfile.name])
+    ret_A = subprocess.call(["python3", WORKING_DIR + "/check_reinvite_rtt.py", sippA_statfile.name])
     if (ret_A != 0):
         logger.debug("Slow ReInvite Detected!")
         return 1

--- a/tests/fax/pjsip/t38_fast_reject/sipp/A_PARTY.xml
+++ b/tests/fax/pjsip/t38_fast_reject/sipp/A_PARTY.xml
@@ -114,7 +114,7 @@
 	</send>
 
 	<!-- Wait to see if Asterisk drops the call after rejecting the T.38 request -->
-	<pause milliseconds="50000" crlf="true" />
+	<pause milliseconds="1000" crlf="true" />
 
 	<send retrans="500">
 		<![CDATA[


### PR DESCRIPTION
The test failures largely fell under one of three categories:

Overall timeout.  SIPp 3.7.5 enforces an overall scenario execution
timeout.  These tests had their timeout manually set in the associated
yaml file.

3pcc termination.  Some tests were exiting prematurely because the
partner scenario terminated.  These tests were modified to include an
end sendcmd/recvcmd to coordinate the termination.

IPV6 'target' flag was set incorrectly.  A number of tests had the
'target' flag set within the key-args dict within the associated yaml.
These tests had the 'target' flag moved outside of the key-args. These
tests were working with earlier versions of SIPp because those
versions used the last target positional arg while 3.7.5 fails if more
than one target positional arg is specified.

Fixes: #107
