### PR TITLE
Fix for race condition on termination of caller_remote attended transfer test

### DIFF
--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_remote/sipp/referee.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_remote/sipp/referee.xml
@@ -101,6 +101,9 @@
     ]]>
   </sendCmd>
 
+
+  <recvCmd optional="true" next="done" />
+
   <recv request="BYE" />
   <send>
     <![CDATA[
@@ -119,6 +122,8 @@
 
   <!-- wait for referer scenario to finish -->
   <recvCmd />
+
+  <label id="done" />
 
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>


### PR DESCRIPTION
A race condition was introduced when addressing SIPp 3.7.5 test failures between
the scenario terminating recvCmd and the final BYE.  This change allows the test
to terminate properly whether the 3pcc command is received before or after the
BYE.
