### PR TITLE
Replace yappcap with scapy for packet capture.

### DIFF
--- a/extras.txt
+++ b/extras.txt
@@ -1,1 +1,0 @@
-https://github.com/asterisk/yappcap/archive/refs/tags/v0.0.5-py3.zip

--- a/lib/python/asterisk/pcap.py
+++ b/lib/python/asterisk/pcap.py
@@ -26,7 +26,7 @@ from construct import *
 from construct.core import *
 from asterisk.pcap_proxy import *
 try:
-    from yappcap import PcapOffline
+    from scapy import interfaces, sendrecv, packet
     PCAP_AVAILABLE = True
 except:
     PCAP_AVAILABLE = False

--- a/lib/python/asterisk/pcap_proxy.py
+++ b/lib/python/asterisk/pcap_proxy.py
@@ -58,7 +58,7 @@ class Packet():
             self.ip_layer = None
             self.transport_layer = None
         else:
-            self.eth_layer = ip_stack.parse(bytes(raw_packet.data))
+            self.eth_layer = ip_stack.parse(bytes(raw_packet))
             self.ip_layer = self.eth_layer.next
             self.transport_layer = self.ip_layer.next
 
@@ -505,7 +505,7 @@ class SIPPacketFactory():
         """
         ret_packet = None
         if not isinstance(packet, str):
-            hex_string = packet.data[42:]
+            hex_string = packet[42:]
             ascii_string = hex_string.decode('ascii')
         else:
             ascii_string = packet

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ cffi==1.17.1
 charset-normalizer==2.0.12
 constantly==15.1.0
 construct==2.10.68
-Cython>=0.29.34,<3.0.0
 hyperlink==21.0.0
 idna==3.3
 incremental==24.7.2
@@ -27,3 +26,4 @@ typing_extensions==4.12.2
 urllib3==1.26.9
 zope.interface==7.0.1
 starpy @ git+https://github.com/asterisk/starpy@1.1.1
+scapy==2.6.1

--- a/setupVenv.sh
+++ b/setupVenv.sh
@@ -16,14 +16,8 @@ function do_pip_setup {
 	python3 -m pip install --upgrade pip
 	python3 -m pip install wheel setuptools build
 	python3 -m pip install -r ./requirements.txt
-	python3 -m pip install -r ./extras.txt || {
-		echo "**************************" >&2
-		echo "Some optional python requirements failed to install. The following tests may not run:" >&2
-		grep -lEr "python\s*:\s*[']?yappcap" tests >&2
-		echo "**************************" >&2
-	}
 	$REALTIME && python3 -m pip install -r ./requirements-realtime.txt
-	md5sum requirements.txt extras.txt requirements-realtime.txt > $1/checksums
+	md5sum requirements.txt requirements-realtime.txt > $1/checksums
 }
 
 if [[ "$VIRTUAL_ENV" != "" ]]

--- a/tests/channels/pjsip/subscriptions/presence/verify_bodies/verify_pidf/test-config.yaml
+++ b/tests/channels/pjsip/subscriptions/presence/verify_bodies/verify_pidf/test-config.yaml
@@ -22,7 +22,7 @@ properties:
             version : 'v3.0'
         - python: 'twisted'
         - python: 'starpy'
-        - python: 'yappcap'
+        - python: 'scapy'
         - asterisk: 'res_pjsip'
         - asterisk: 'res_pjsip_exten_state'
         - asterisk: 'res_pjsip_pidf_body_generator'
@@ -47,6 +47,7 @@ test-modules:
 sipp-config:
     reactor-timeout: 30
     fail-on-any: True
+    stop-after-scenarios: False
     test-iterations:
         -
             scenarios:

--- a/tests/channels/pjsip/subscriptions/presence/verify_bodies/verify_xpidf/test-config.yaml
+++ b/tests/channels/pjsip/subscriptions/presence/verify_bodies/verify_xpidf/test-config.yaml
@@ -22,7 +22,7 @@ properties:
             version : 'v3.0'
         - python: 'twisted'
         - python: 'starpy'
-        - python: 'yappcap'
+        - python: 'scapy'
         - asterisk: 'res_pjsip'
         - asterisk: 'res_pjsip_exten_state'
         - asterisk: 'res_pjsip_xpidf_body_generator'
@@ -47,6 +47,7 @@ test-modules:
 sipp-config:
     reactor-timeout: 30
     fail-on-any: True
+    stop-after-scenarios: False
     test-iterations:
         -
             scenarios:

--- a/tests/channels/pjsip/subscriptions/rls/rls_test.py
+++ b/tests/channels/pjsip/subscriptions/rls/rls_test.py
@@ -52,7 +52,7 @@ def log_packet(packet, write_packet_contents):
     """Writes the contents of a SIP packet to the log.
 
     Keyword Arguments:
-    packet                  -- A yappcap.PcapPacket
+    packet                  -- A PcapPacket
     write_packet_contents   -- Whether or not to dump the contents of the
                                packet to the log.
     """

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local_direct_media/test-config.yaml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local_direct_media/test-config.yaml
@@ -105,10 +105,7 @@ properties:
     dependencies:
         - python : twisted
         - python : starpy
-        - python : yappcap
-        - python : pyxb
         - asterisk : res_pjsip
-        - custom : rawsocket
         - app : sipp
     tags:
         - pjsip

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_direct_media/test-config.yaml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_direct_media/test-config.yaml
@@ -107,11 +107,8 @@ properties:
     dependencies:
         - python : twisted
         - python : starpy
-        - python : yappcap
-        - python : pyxb
         - app: 'sipp'
         - asterisk : res_pjsip
-        #- custom : rawsocket
     tags:
         - pjsip
         - refleaks

--- a/tests/codecs/opus/fec/jitterbuffer/adaptive/test-config.yaml
+++ b/tests/codecs/opus/fec/jitterbuffer/adaptive/test-config.yaml
@@ -33,7 +33,7 @@ rtp-analyzer-config:
 properties:
     dependencies:
         - python: 'twisted'
-        - python: 'yappcap'
+        - python: 'scapy'
         - asterisk : 'app_dial'
         - asterisk : 'res_pjsip'
         - asterisk : 'codec_opus'

--- a/tests/codecs/opus/fec/jitterbuffer/fixed/test-config.yaml
+++ b/tests/codecs/opus/fec/jitterbuffer/fixed/test-config.yaml
@@ -33,7 +33,7 @@ rtp-analyzer-config:
 properties:
     dependencies:
         - python: 'twisted'
-        - python: 'yappcap'
+        - python: 'scapy'
         - asterisk : 'app_dial'
         - asterisk : 'res_pjsip'
         - asterisk : 'codec_opus'

--- a/tests/codecs/opus/fec/no_jitterbuffer/test-config.yaml
+++ b/tests/codecs/opus/fec/no_jitterbuffer/test-config.yaml
@@ -33,7 +33,7 @@ rtp-analyzer-config:
 properties:
     dependencies:
         - python: 'twisted'
-        - python: 'yappcap'
+        - python: 'scapy'
         - asterisk : 'app_dial'
         - asterisk : 'res_pjsip'
         - asterisk : 'codec_opus'


### PR DESCRIPTION
Yappcap will never build again because of ancient Cython so it's been
replaced with "scapy" which is popular and well maintained.

* The extra.txt requirements file was removed as it's no longer needed.

* The verify_pidf and verify_xpidf tests needed minor tweaks to make them
reliable because the tests ended with the sipp scenarios before the
validation could complete.

* The callee_local_direct_media and caller_local_direct_media tests indicated
that they needed yappcap and pyxb but they actually need neither so those
dependencies were removed.  The tests still have issues however so they
remain skipped.

* The codec_opus tests all fail for other reasons but they never get run
anyway. Issue opened.
