### PR TITLE
stasis_bridge_to_stasis_app_ari_only: add timeout at end of referer scenario

### DIFF
--- a/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_app_ari_only/sipp/referer.xml
+++ b/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_app_ari_only/sipp/referer.xml
@@ -169,6 +169,8 @@
   </send>
   <recv response="200" />
 
+  <pause milliseconds="1000" />
+
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
 


### PR DESCRIPTION
Adding a 1000ms delay to the end of the referer scenario for the referee to have
time to receive it's final BYE under SIPp 3.7.5
