### PR TITLE
caller_local_blonde: wait for referee termination before sending BYE

### DIFF
--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/sipp/referer.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/sipp/referer.xml
@@ -201,6 +201,9 @@
     ]]>
   </send>
 
+  <!-- wait for referee scenario to finish then terminate this leg -->
+  <recvCmd />
+
   <send retrans="500">
     <![CDATA[
 
@@ -223,9 +226,6 @@
   <recv response="200" rtd="true" crlf="true" optional="true" />
 
   <label id="done"/>
-
-  <!-- wait for referee scenario to finish -->
-  <recvCmd />
 
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>


### PR DESCRIPTION
Instead of waiting for the referee to finish after sending BYE, wait for the
referee to finish then send the BYE.  This avoids a potential race condition
of receiving the termination cmd before sending the BYE, which breaks the
referer scenario.
