### PR TITLE
callee_local_blonde: wait for referee termination before sending BYE

### DIFF
--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local_blonde/sipp/referer_uas.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local_blonde/sipp/referer_uas.xml
@@ -190,6 +190,9 @@
     ]]>
   </send>
 
+  <!-- wait for referee scenario to finish -->
+  <recvCmd />
+
   <send retrans="500">
     <![CDATA[
 
@@ -207,10 +210,7 @@
     ]]>
   </send>
 
-  <recv response="200" rtd="true" crlf="true" />
-
-  <!-- wait for referee scenario to finish -->
-  <recvCmd />
+  <recv response="200" rtd="true" crlf="true"/>
 
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>


### PR DESCRIPTION
Instead of waiting for the referee to finish after sending BYE, wait for the
referee to finish then send the BYE.  This avoids a potential race condition
of receiving the termination cmd before sending the BYE, which breaks the
referer scenario.
