### PR TITLE
callee_local: replacing pause with timed wait for re-INVITE

### DIFF
--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local/sipp/referee.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local/sipp/referee.xml
@@ -48,10 +48,9 @@
       s=-
       c=IN IP[media_ip_type] [media_ip]
       t=0 0
-      m=audio [media_port] RTP/AVP 0 101
+      m=audio [media_port] RTP/AVP 0
       a=sendrecv
       a=rtpmap:0 PCMU/8000
-      a=rtpmap:101 telephone-event/8000
 
     ]]>
   </send>
@@ -91,7 +90,37 @@
     ]]>
   </send>
 
-  <pause milliseconds="1000" />
+  <recv request="INVITE" crlf="true" timeout="1000" ontimeout="norei" />
+
+  <send retrans="500">
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:];tag=[call_number]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: sip:bob@[local_ip]:[local_port]
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=- 1324901698 1324901698 IN IP[local_ip_type] [local_ip]
+      s=-
+      c=IN IP[media_ip_type] [media_ip]
+      t=0 0
+      m=audio [media_port] RTP/AVP 0
+      a=sendrecv
+      a=rtpmap:0 PCMU/8000
+
+    ]]>
+  </send>
+
+  <recv request="ACK" />
+
+  <label id="norei" />
+
   <sendCmd>
     <![CDATA[
       Call-ID: [$original_callid]

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local/sipp/referer_uas.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/callee_local/sipp/referer_uas.xml
@@ -81,10 +81,9 @@
       s=-
       c=IN IP[media_ip_type] [media_ip]
       t=0 0
-      m=audio [media_port] RTP/AVP 0 101
+      m=audio [media_port] RTP/AVP 0
       a=sendonly
       a=rtpmap:0 PCMU/8000
-      a=rtpmap:101 telephone-event/8000
 
     ]]>
   </send>


### PR DESCRIPTION
Under some timing circumstances, Asterisk is sending a re-INVITE while the
referee scenario is paused, which causes a test failure.  This change
replaces the pause with a timed wait for INVITE, which results in the same
pause but also handles the re-INVITE.
