### PR TITLE
Python package updates for Python 3.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ construct==2.10.68
 hyperlink==21.0.0
 idna==3.3
 incremental==24.7.2
-lxml==5.3.0
+lxml==6.0.1
 netifaces>=0.10.4
 numpy>=1.19.5
 pycparser==2.22
@@ -20,10 +20,10 @@ rawsocket==0.2
 requests==2.27.1
 service_identity==24.1.0
 six==1.16.0
-Twisted==24.10.0
+Twisted==25.5.0
 txaio==22.2.1
 typing_extensions==4.12.2
 urllib3==1.26.9
-zope.interface==7.0.1
+zope.interface==8.0.1
 starpy @ git+https://github.com/asterisk/starpy@1.1.1
 scapy==2.6.1


### PR DESCRIPTION
The lxml, Twisted and zope.interface packages need to be updated to support
Python 3.14.  Backwards compatibility with 3.12,3.13 is maintained.
