### PR TITLE
chan_iax2: Add nominal and off-nominal auth tests

### DIFF
--- a/tests/channels/iax2/acl_call/test-config.yaml
+++ b/tests/channels/iax2/acl_call/test-config.yaml
@@ -10,6 +10,7 @@ properties:
     dependencies:
         - python : 'twisted'
         - python : 'starpy'
+        - asterisk : 'chan_iax2'
     tags:
         - iax2
         - ACL

--- a/tests/channels/iax2/authed-calls/nominal/md5/configs/ast1/extensions.conf
+++ b/tests/channels/iax2/authed-calls/nominal/md5/configs/ast1/extensions.conf
@@ -1,0 +1,8 @@
+[general]
+
+[globals]
+
+[iaxtest]
+
+exten => 1000,1,Answer()
+exten => 1000,n,Echo()

--- a/tests/channels/iax2/authed-calls/nominal/md5/configs/ast1/iax.conf
+++ b/tests/channels/iax2/authed-calls/nominal/md5/configs/ast1/iax.conf
@@ -1,0 +1,13 @@
+[general]
+
+bindport=4570
+bindaddr=127.0.0.1
+
+disallow=all
+allow=ulaw
+
+[guest70]
+type=user
+context=iaxtest
+auth=md5
+secret=passw0rd

--- a/tests/channels/iax2/authed-calls/nominal/md5/configs/ast2/extensions.conf
+++ b/tests/channels/iax2/authed-calls/nominal/md5/configs/ast2/extensions.conf
@@ -1,0 +1,9 @@
+[general]
+
+[globals]
+
+[iaxtest]
+
+exten => 1000,1,Answer()
+exten => 1000,n,Wait(1)
+exten => 1000,n,Hangup()

--- a/tests/channels/iax2/authed-calls/nominal/md5/configs/ast2/iax.conf
+++ b/tests/channels/iax2/authed-calls/nominal/md5/configs/ast2/iax.conf
@@ -1,0 +1,13 @@
+[general]
+
+bindport=4569
+bindaddr=127.0.0.1
+
+disallow=all
+allow=ulaw
+
+[guest69]
+type=user
+context=iaxtest
+auth=md5
+secret=passw0rd

--- a/tests/channels/iax2/authed-calls/nominal/md5/test-config.yaml
+++ b/tests/channels/iax2/authed-calls/nominal/md5/test-config.yaml
@@ -1,0 +1,90 @@
+testinfo:
+    summary:     'Test a basic IAX2 call using MD5 authentication'
+    description: |
+        'This test initiates an IAX2 call between 2 instances of Asterisk.
+        The test only verifies that an IAX2 call is accepted with good
+        authentication.'
+
+properties:
+    dependencies:
+        - python : 'twisted'
+        - python : 'starpy'
+        - asterisk : 'chan_iax2'
+    tags:
+        - iax2
+
+test-modules:
+    test-object:
+        config-section: test-object-config
+        typename: 'test_case.TestCaseModule'
+    modules:
+        -
+            config-section: originator
+            typename: 'pluggable_modules.Originator'
+        -
+            config-section: ami-config
+            typename: 'ami.AMIEventModule'
+        -
+            config-section: hangup-monitor
+            typename: 'pluggable_modules.HangupMonitor'
+
+test-object-config:
+    asterisk-instances: 2
+    connect-ami: True
+
+originator:
+    trigger: 'ami_connect'
+    id: '0'
+    channel: 'IAX2/guest69:passw0rd@127.0.0.1:4569/1000'
+    context: 'iaxtest'
+    exten: '1000'
+    priority: '1'
+    async: 'True'
+
+ami-config:
+    -
+        id: '0'
+        type: 'headermatch'
+        count: '1'
+        conditions:
+            match:
+                Event: 'Newchannel'
+        requirements:
+            match:
+                Channel: 'IAX2/.*'
+    -
+        id: '1'
+        type: 'headermatch'
+        count: '1'
+        conditions:
+            match:
+                Event: 'Newchannel'
+        requirements:
+            match:
+                Channel: 'IAX2/.*'
+    -
+        id: '0'
+        type: 'headermatch'
+        count: '1'
+        conditions:
+            match:
+                Event: 'Hangup'
+        requirements:
+            match:
+                Channel: 'IAX2/.*'
+                Cause: '16'
+    -
+        id: '1'
+        type: 'headermatch'
+        count: '1'
+        conditions:
+            match:
+                Event: 'Hangup'
+        requirements:
+            match:
+                Channel: 'IAX2/.*'
+                Cause: '16'
+
+hangup-monitor:
+    ids: '0'
+

--- a/tests/channels/iax2/authed-calls/nominal/plain/configs/ast1/extensions.conf
+++ b/tests/channels/iax2/authed-calls/nominal/plain/configs/ast1/extensions.conf
@@ -1,0 +1,8 @@
+[general]
+
+[globals]
+
+[iaxtest]
+
+exten => 1000,1,Answer()
+exten => 1000,n,Echo()

--- a/tests/channels/iax2/authed-calls/nominal/plain/configs/ast1/iax.conf
+++ b/tests/channels/iax2/authed-calls/nominal/plain/configs/ast1/iax.conf
@@ -1,0 +1,13 @@
+[general]
+
+bindport=4570
+bindaddr=127.0.0.1
+
+disallow=all
+allow=ulaw
+
+[guest70]
+type=user
+context=iaxtest
+auth=plaintext
+secret=passw0rd

--- a/tests/channels/iax2/authed-calls/nominal/plain/configs/ast2/extensions.conf
+++ b/tests/channels/iax2/authed-calls/nominal/plain/configs/ast2/extensions.conf
@@ -1,0 +1,9 @@
+[general]
+
+[globals]
+
+[iaxtest]
+
+exten => 1000,1,Answer()
+exten => 1000,n,Wait(1)
+exten => 1000,n,Hangup()

--- a/tests/channels/iax2/authed-calls/nominal/plain/configs/ast2/iax.conf
+++ b/tests/channels/iax2/authed-calls/nominal/plain/configs/ast2/iax.conf
@@ -1,0 +1,13 @@
+[general]
+
+bindport=4569
+bindaddr=127.0.0.1
+
+disallow=all
+allow=ulaw
+
+[guest69]
+type=user
+context=iaxtest
+auth=plaintext
+secret=passw0rd

--- a/tests/channels/iax2/authed-calls/nominal/plain/test-config.yaml
+++ b/tests/channels/iax2/authed-calls/nominal/plain/test-config.yaml
@@ -1,0 +1,90 @@
+testinfo:
+    summary:     'Test a basic IAX2 call using plaintext authentication'
+    description: |
+        'This test initiates an IAX2 call between 2 instances of Asterisk.
+        The test only verifies that an IAX2 call is accepted with good
+        authentication.'
+
+properties:
+    dependencies:
+        - python : 'twisted'
+        - python : 'starpy'
+        - asterisk : 'chan_iax2'
+    tags:
+        - iax2
+
+test-modules:
+    test-object:
+        config-section: test-object-config
+        typename: 'test_case.TestCaseModule'
+    modules:
+        -
+            config-section: originator
+            typename: 'pluggable_modules.Originator'
+        -
+            config-section: ami-config
+            typename: 'ami.AMIEventModule'
+        -
+            config-section: hangup-monitor
+            typename: 'pluggable_modules.HangupMonitor'
+
+test-object-config:
+    asterisk-instances: 2
+    connect-ami: True
+
+originator:
+    trigger: 'ami_connect'
+    id: '0'
+    channel: 'IAX2/guest69:passw0rd@127.0.0.1:4569/1000'
+    context: 'iaxtest'
+    exten: '1000'
+    priority: '1'
+    async: 'True'
+
+ami-config:
+    -
+        id: '0'
+        type: 'headermatch'
+        count: '1'
+        conditions:
+            match:
+                Event: 'Newchannel'
+        requirements:
+            match:
+                Channel: 'IAX2/.*'
+    -
+        id: '1'
+        type: 'headermatch'
+        count: '1'
+        conditions:
+            match:
+                Event: 'Newchannel'
+        requirements:
+            match:
+                Channel: 'IAX2/.*'
+    -
+        id: '0'
+        type: 'headermatch'
+        count: '1'
+        conditions:
+            match:
+                Event: 'Hangup'
+        requirements:
+            match:
+                Channel: 'IAX2/.*'
+                Cause: '16'
+    -
+        id: '1'
+        type: 'headermatch'
+        count: '1'
+        conditions:
+            match:
+                Event: 'Hangup'
+        requirements:
+            match:
+                Channel: 'IAX2/.*'
+                Cause: '16'
+
+hangup-monitor:
+    ids: '0'
+

--- a/tests/channels/iax2/authed-calls/nominal/tests.yaml
+++ b/tests/channels/iax2/authed-calls/nominal/tests.yaml
@@ -1,0 +1,4 @@
+# Enter tests here in the order they should be considered for execution:
+tests:
+    - test: 'md5'
+    - test: 'plain'

--- a/tests/channels/iax2/authed-calls/off-nominal/md5/configs/ast1/extensions.conf
+++ b/tests/channels/iax2/authed-calls/off-nominal/md5/configs/ast1/extensions.conf
@@ -1,0 +1,8 @@
+[general]
+
+[globals]
+
+[iaxtest]
+
+exten => 1000,1,Answer()
+exten => 1000,n,Echo()

--- a/tests/channels/iax2/authed-calls/off-nominal/md5/configs/ast1/iax.conf
+++ b/tests/channels/iax2/authed-calls/off-nominal/md5/configs/ast1/iax.conf
@@ -1,0 +1,13 @@
+[general]
+
+bindport=4570
+bindaddr=127.0.0.1
+
+disallow=all
+allow=ulaw
+
+[guest70]
+type=user
+context=iaxtest
+auth=md5
+secret=passw0rd

--- a/tests/channels/iax2/authed-calls/off-nominal/md5/configs/ast2/extensions.conf
+++ b/tests/channels/iax2/authed-calls/off-nominal/md5/configs/ast2/extensions.conf
@@ -1,0 +1,9 @@
+[general]
+
+[globals]
+
+[iaxtest]
+
+exten => 1000,1,Answer()
+exten => 1000,n,Wait(1)
+exten => 1000,n,Hangup()

--- a/tests/channels/iax2/authed-calls/off-nominal/md5/configs/ast2/iax.conf
+++ b/tests/channels/iax2/authed-calls/off-nominal/md5/configs/ast2/iax.conf
@@ -1,0 +1,13 @@
+[general]
+
+bindport=4569
+bindaddr=127.0.0.1
+
+disallow=all
+allow=ulaw
+
+[guest69]
+type=user
+context=iaxtest
+auth=md5
+secret=NOTpassw0rd

--- a/tests/channels/iax2/authed-calls/off-nominal/md5/test-config.yaml
+++ b/tests/channels/iax2/authed-calls/off-nominal/md5/test-config.yaml
@@ -1,0 +1,59 @@
+testinfo:
+    summary:     'Test a basic IAX2 call using MD5 authentication'
+    description: |
+        'This test initiates an IAX2 call between 2 instances of Asterisk.
+        The test only verifies that an IAX2 call is rejected because of a
+        password mismatch.'
+
+properties:
+    dependencies:
+        - python : 'twisted'
+        - python : 'starpy'
+        - asterisk : 'chan_iax2'
+    tags:
+        - iax2
+
+test-modules:
+    test-object:
+        config-section: test-object-config
+        typename: 'test_case.TestCaseModule'
+    modules:
+        -
+            config-section: originator
+            typename: 'pluggable_modules.Originator'
+        -
+            config-section: ami-config
+            typename: 'ami.AMIEventModule'
+        -
+            config-section: hangup-monitor
+            typename: 'pluggable_modules.HangupMonitor'
+
+test-object-config:
+    asterisk-instances: 2
+    connect-ami: True
+
+originator:
+    trigger: 'ami_connect'
+    id: '0'
+    channel: 'IAX2/guest69:passw0rd@127.0.0.1:4569/1000'
+    context: 'iaxtest'
+    exten: '1000'
+    priority: '1'
+    async: 'True'
+
+ami-config:
+    -
+        id: '0'
+        type: 'headermatch'
+        count: '1'
+        conditions:
+            match:
+                Event: 'Hangup'
+        requirements:
+            match:
+                Channel: 'IAX2/.*'
+                Cause: '50'
+
+hangup-monitor:
+    ids: '0'
+

--- a/tests/channels/iax2/authed-calls/off-nominal/plain/configs/ast1/extensions.conf
+++ b/tests/channels/iax2/authed-calls/off-nominal/plain/configs/ast1/extensions.conf
@@ -1,0 +1,8 @@
+[general]
+
+[globals]
+
+[iaxtest]
+
+exten => 1000,1,Answer()
+exten => 1000,n,Echo()

--- a/tests/channels/iax2/authed-calls/off-nominal/plain/configs/ast1/iax.conf
+++ b/tests/channels/iax2/authed-calls/off-nominal/plain/configs/ast1/iax.conf
@@ -1,0 +1,13 @@
+[general]
+
+bindport=4570
+bindaddr=127.0.0.1
+
+disallow=all
+allow=ulaw
+
+[guest70]
+type=user
+context=iaxtest
+auth=plaintext
+secret=passw0rd

--- a/tests/channels/iax2/authed-calls/off-nominal/plain/configs/ast2/cdr.conf
+++ b/tests/channels/iax2/authed-calls/off-nominal/plain/configs/ast2/cdr.conf
@@ -1,0 +1,7 @@
+[general]
+unanswered=yes
+[csv]
+usegmtime=yes    ; log date/time in GMT.  Default is "no"
+loguniqueid=yes  ; log uniqueid.  Default is "no"
+loguserfield=yes ; log user field.  Default is "no"
+

--- a/tests/channels/iax2/authed-calls/off-nominal/plain/configs/ast2/extensions.conf
+++ b/tests/channels/iax2/authed-calls/off-nominal/plain/configs/ast2/extensions.conf
@@ -1,0 +1,9 @@
+[general]
+
+[globals]
+
+[iaxtest]
+
+exten => 1000,1,Answer()
+exten => 1000,n,Wait(1)
+exten => 1000,n,Hangup()

--- a/tests/channels/iax2/authed-calls/off-nominal/plain/configs/ast2/iax.conf
+++ b/tests/channels/iax2/authed-calls/off-nominal/plain/configs/ast2/iax.conf
@@ -1,0 +1,13 @@
+[general]
+
+bindport=4569
+bindaddr=127.0.0.1
+
+disallow=all
+allow=ulaw
+
+[guest69]
+type=user
+context=iaxtest
+auth=md5
+secret=NOTpassw0rd

--- a/tests/channels/iax2/authed-calls/off-nominal/plain/test-config.yaml
+++ b/tests/channels/iax2/authed-calls/off-nominal/plain/test-config.yaml
@@ -1,0 +1,59 @@
+testinfo:
+    summary:     'Test a basic IAX2 call using plaintext authentication'
+    description: |
+        'This test initiates an IAX2 call between 2 instances of Asterisk.
+        The test only verifies that an IAX2 call is rejected because of a
+        password mismatch.'
+
+properties:
+    dependencies:
+        - python : 'twisted'
+        - python : 'starpy'
+        - asterisk : 'chan_iax2'
+    tags:
+        - iax2
+
+test-modules:
+    test-object:
+        config-section: test-object-config
+        typename: 'test_case.TestCaseModule'
+    modules:
+        -
+            config-section: originator
+            typename: 'pluggable_modules.Originator'
+        -
+            config-section: ami-config
+            typename: 'ami.AMIEventModule'
+        -
+            config-section: hangup-monitor
+            typename: 'pluggable_modules.HangupMonitor'
+
+test-object-config:
+    asterisk-instances: 2
+    connect-ami: True
+
+originator:
+    trigger: 'ami_connect'
+    id: '0'
+    channel: 'IAX2/guest69:passw0rd@127.0.0.1:4569/1000'
+    context: 'iaxtest'
+    exten: '1000'
+    priority: '1'
+    async: 'True'
+
+ami-config:
+    -
+        id: '0'
+        type: 'headermatch'
+        count: '1'
+        conditions:
+            match:
+                Event: 'Hangup'
+        requirements:
+            match:
+                Channel: 'IAX2/.*'
+                Cause: '50'
+
+hangup-monitor:
+    ids: '0'
+

--- a/tests/channels/iax2/authed-calls/off-nominal/tests.yaml
+++ b/tests/channels/iax2/authed-calls/off-nominal/tests.yaml
@@ -1,0 +1,4 @@
+# Enter tests here in the order they should be considered for execution:
+tests:
+    - test: 'md5'
+    - test: 'plain'

--- a/tests/channels/iax2/authed-calls/tests.yaml
+++ b/tests/channels/iax2/authed-calls/tests.yaml
@@ -1,0 +1,4 @@
+# Enter tests here in the order they should be considered for execution:
+tests:
+    - dir: 'nominal'
+    - dir: 'off-nominal'

--- a/tests/channels/iax2/basic-call/test-config.yaml
+++ b/tests/channels/iax2/basic-call/test-config.yaml
@@ -10,6 +10,7 @@ properties:
     dependencies:
         - python : 'twisted'
         - python : 'starpy'
+        - asterisk : 'chan_iax2'
         - asterisk : 'cdr_csv'
     tags:
         - iax2

--- a/tests/channels/iax2/encrypted-calls/md5/test-config.yaml
+++ b/tests/channels/iax2/encrypted-calls/md5/test-config.yaml
@@ -10,6 +10,7 @@ properties:
     dependencies:
         - python : 'twisted'
         - python : 'starpy'
+        - asterisk : 'chan_iax2'
         - asterisk : 'cdr_csv'
     tags:
         - iax2

--- a/tests/channels/iax2/encrypted-calls/rsa-dynamic/test-config.yaml
+++ b/tests/channels/iax2/encrypted-calls/rsa-dynamic/test-config.yaml
@@ -10,6 +10,7 @@ properties:
     dependencies:
         - python : 'twisted'
         - python : 'starpy'
+        - asterisk : 'chan_iax2'
         - asterisk : 'cdr_csv'
     tags:
         - iax2

--- a/tests/channels/iax2/encrypted-calls/rsa/test-config.yaml
+++ b/tests/channels/iax2/encrypted-calls/rsa/test-config.yaml
@@ -10,6 +10,7 @@ properties:
     dependencies:
         - python : 'twisted'
         - python : 'starpy'
+        - asterisk : 'chan_iax2'
         - asterisk : 'cdr_csv'
     tags:
         - iax2

--- a/tests/channels/iax2/tests.yaml
+++ b/tests/channels/iax2/tests.yaml
@@ -1,6 +1,7 @@
 # Enter tests here in the order they should be considered for execution:
 tests:
     - dir: 'encrypted-calls'
+    - dir: 'authed-calls'
     - test: 'basic-call'
     - test: 'hangupcause'
     - test: 'acl_call'


### PR DESCRIPTION
Also added missing chan_iax2 dependency for some other tests.
