### PR TITLE
Added tests for getting/setting multiple channel variables via ARI.

### DIFF
--- a/tests/rest_api/channels/channel_variables/get_set_multiple/configs/ast1/extensions.conf
+++ b/tests/rest_api/channels/channel_variables/get_set_multiple/configs/ast1/extensions.conf
@@ -1,0 +1,7 @@
+[default]
+
+exten => s,1,NoOp()
+	same => n,Answer()
+	same => n,Playback(silence/1&please-try-again&silence/3)
+	same => n,Hangup()
+

--- a/tests/rest_api/channels/channel_variables/get_set_multiple/test-config.yaml
+++ b/tests/rest_api/channels/channel_variables/get_set_multiple/test-config.yaml
@@ -1,0 +1,72 @@
+testinfo:
+    summary: 'Test getting/setting multiple channel variables simultaneously via ARI.'
+    description: |
+        'Create a channel. Set some channel variables on the newly
+        created channel. Then, get those channel variables to ensure
+        everything worked as expected.'
+
+test-modules:
+    test-object:
+        config-section: 'test-object-config'
+        typename: 'ari.AriBaseTestObject'
+    modules:
+    -   config-section: 'pluggable-config'
+        typename: 'pluggable_modules.EventActionModule'
+
+test-object-config:
+    apps: 'testsuite'
+    reactor-timeout: 15
+    stop-on-end: False
+
+pluggable-config:
+    -   ari-start:
+        ari-requests:
+            -   method: 'post'
+                uri: 'channels/create'
+                params:
+                    endpoint: 'Local/s@default'
+                    app: 'testsuite'
+                    channelId: 'channel1'
+                expect: 200
+
+    -   ari-events:
+            match:
+                type: 'StasisStart'
+                application: 'testsuite'
+                channel:
+                    id: 'channel1'
+            count: 1
+        ari-requests:
+            -   method: 'post'
+                uri: 'channels/channel1/variables'
+                body: {'variables': {'TESTVAR1': 'test1', 'TESTVAR2 ': 'test2', ' TESTVAR3': 'test3'}}
+                expect: 204
+            -   method: 'get'
+                uri: 'channels/channel1/variables'
+                params:
+                    variables: ' TESTVAR1, TESTVAR2 ,TESTVAR3'
+                expect: 200
+                response_body:
+                    match: {'variables': {'TESTVAR1': 'test1', 'TESTVAR2': 'test2', 'TESTVAR3': 'test3'}}
+            -   method: 'delete'
+                uri: 'channels/channel1'
+                expect: 204
+
+    -   ari-events:
+            match:
+                type: 'StasisEnd'
+                application: 'testsuite'
+                channel:
+                    id: 'channel1'
+            count: 1
+        stop_test:
+
+properties:
+    dependencies:
+    -   python: 'autobahn.websocket'
+    -   python: 'requests'
+    -   python: 'twisted'
+    -   python: 'starpy'
+    -   asterisk: 'res_ari_channels'
+    tags:
+    - ARI

--- a/tests/rest_api/channels/channel_variables/tests.yaml
+++ b/tests/rest_api/channels/channel_variables/tests.yaml
@@ -1,0 +1,2 @@
+tests:
+    - test: 'get_set_multiple'

--- a/tests/rest_api/channels/tests.yaml
+++ b/tests/rest_api/channels/tests.yaml
@@ -18,3 +18,4 @@ tests:
     - test: 'create_duplicate_id'
     - dir: 'rtp_statistics'
     - dir: 'external_media'
+    - dir: 'channel_variables'


### PR DESCRIPTION
This test adds coverage for getting/setting multiple channel variables
via '/channels/{channelId}/variables' using both GET and POST.
