### PR TITLE
rest_api/channels: Add test for whispering with no underlying stream

### DIFF
--- a/tests/rest_api/channels/snoop_whisper_no_normal_flowing_audio/channel_whisper.py
+++ b/tests/rest_api/channels/snoop_whisper_no_normal_flowing_audio/channel_whisper.py
@@ -1,0 +1,25 @@
+'''
+Copyright (C) 2013, Digium, Inc.
+Joshua Colp <jcolp@digium.com>
+
+This program is free software, distributed under the terms of
+the GNU General Public License Version 2.
+'''
+
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+def on_start(ari, event, test_object):
+    LOGGER.debug("on_start(%r)" % event)
+    ari.post('channels', event['channel']['id'], 'snoop',
+             spy='none', whisper='out', app='testsuite', appArgs='snoop')
+    return True
+
+
+def on_snoop_start(ari, event, test_object):
+    LOGGER.debug("on_snoop_start(%r)" % event)
+    ari.post('channels', event['channel']['id'], 'play',
+             media='sound:demo-congrats')
+    return True

--- a/tests/rest_api/channels/snoop_whisper_no_normal_flowing_audio/configs/ast1/extensions.conf
+++ b/tests/rest_api/channels/snoop_whisper_no_normal_flowing_audio/configs/ast1/extensions.conf
@@ -1,0 +1,6 @@
+[default]
+
+exten => s,1,NoOp()
+	same => n,Answer()
+	same => n,Stasis(testsuite)
+	same => n,Hangup()

--- a/tests/rest_api/channels/snoop_whisper_no_normal_flowing_audio/test-config.yaml
+++ b/tests/rest_api/channels/snoop_whisper_no_normal_flowing_audio/test-config.yaml
@@ -1,0 +1,80 @@
+testinfo:
+    summary: Test whispering calls using ARI without an underlying stream on the hooked channel.
+    description: |
+        Originate a call and whisper to it using ARI.
+
+test-modules:
+    add-test-to-search-path: True
+    test-object:
+        config-section: test-object-config
+        typename: ari.AriTestObject
+    modules:
+        -   config-section: ari-config
+            typename: ari.WebSocketEventModule
+        -
+            config-section: ami-uut
+            typename: 'ami.AMIEventModule'
+
+test-object-config:
+    test-iterations:
+        -
+            -   channel: Local/s@default
+                application: AMD
+
+ami-uut:
+    -
+        type: 'headermatch'
+        id: '0'
+        conditions:
+            match:
+                Event: 'VarSet'
+                Variable: 'AMDSTATUS'
+                Value: 'MACHINE'
+        count: '1'
+    -
+        type: 'headermatch'
+        id: '0'
+        conditions:
+            match:
+                Event: 'ChanSpyStart'
+        count: '1'
+    -
+        type: 'headermatch'
+        id: '0'
+        conditions:
+            match:
+                Event: 'ChanSpyStop'
+        count: '1'
+
+ari-config:
+    apps: testsuite
+    events:
+        -   conditions:
+                match:
+                    type: StasisStart
+                    application: testsuite
+                    args: []
+            count: 1
+            callback:
+                module: channel_whisper
+                method: on_start
+        -   conditions:
+                match:
+                    type: StasisStart
+                    application: testsuite
+                    args: ['snoop']
+            count: 1
+            callback:
+                module: channel_whisper
+                method: on_snoop_start
+
+properties:
+    dependencies:
+        - python : autobahn.websocket
+        - python : requests
+        - python : twisted
+        - python : starpy
+        - asterisk : res_ari_channels
+        - asterisk : app_amd
+    tags:
+        - ARI

--- a/tests/rest_api/channels/tests.yaml
+++ b/tests/rest_api/channels/tests.yaml
@@ -6,6 +6,7 @@ tests:
     - test: 'originate_then_continue'
     - test: 'originate_to_pjsip_endpoint'
     - test: 'snoop_whisper'
+    - test: 'snoop_whisper_no_normal_flowing_audio'
     - test: 'snoop_spy'
     - test: 'snoop_id'
     - dir: 'playback'


### PR DESCRIPTION
Adds a test to detect whispered audio when there is no underlying
stream being sent to the channel.
