### PR TITLE
rest_api/external_interaction/attended_transfer: Add delay to end of referer scenarios.

### DIFF
--- a/tests/rest_api/external_interaction/attended_transfer/non_stasis_app_to_stasis_bridge/sipp/referer.xml
+++ b/tests/rest_api/external_interaction/attended_transfer/non_stasis_app_to_stasis_bridge/sipp/referer.xml
@@ -157,9 +157,14 @@
     ]]>
   </send>
 
-  <!-- Keep the call open for a while in case the 200 is lost to be     -->
-  <!-- able to retransmit it if we receive the BYE again.               -->
-  <pause milliseconds="500"/>
+  <!--
+  This scenario is the 3pcc master so if it ends before the referee scenario,
+  the referee scenario will abort and the test will fail.  The two second pause
+  will allow the referee scenario to end first.  The the test case will kill this
+  scenario before the two seconds is up so no time is actually added to the overall
+  run time.
+  -->
+  <pause milliseconds="2000"/>
 
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>

--- a/tests/rest_api/external_interaction/attended_transfer/non_stasis_bridge_to_stasis_bridge/sipp/referer.xml
+++ b/tests/rest_api/external_interaction/attended_transfer/non_stasis_bridge_to_stasis_bridge/sipp/referer.xml
@@ -157,9 +157,14 @@
     ]]>
   </send>
 
-  <!-- Keep the call open for a while in case the 200 is lost to be     -->
-  <!-- able to retransmit it if we receive the BYE again.               -->
-  <pause milliseconds="500"/>
+  <!--
+  This scenario is the 3pcc master so if it ends before the referee scenario,
+  the referee scenario will abort and the test will fail.  The two second pause
+  will allow the referee scenario to end first.  The the test case will kill this
+  scenario before the two seconds is up so no time is actually added to the overall
+  run time.
+  -->
+  <pause milliseconds="2000"/>
 
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>

--- a/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_non_stasis_app/sipp/referer.xml
+++ b/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_non_stasis_app/sipp/referer.xml
@@ -169,6 +169,15 @@
   </send>
   <recv response="200" />
 
+  <!--
+  This scenario is the 3pcc master so if it ends before the referee scenario,
+  the referee scenario will abort and the test will fail.  The two second pause
+  will allow the referee scenario to end first.  The the test case will kill this
+  scenario before the two seconds is up so no time is actually added to the overall
+  run time.
+  -->
+  <pause milliseconds="2000"/>
+
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
 

--- a/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_app/sipp/referer.xml
+++ b/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_app/sipp/referer.xml
@@ -169,6 +169,15 @@
   </send>
   <recv response="200" />
 
+  <!--
+  This scenario is the 3pcc master so if it ends before the referee scenario,
+  the referee scenario will abort and the test will fail.  The two second pause
+  will allow the referee scenario to end first.  The the test case will kill this
+  scenario before the two seconds is up so no time is actually added to the overall
+  run time.
+  -->
+  <pause milliseconds="2000"/>
+
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
 

--- a/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_app_ari_only/sipp/referer.xml
+++ b/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_app_ari_only/sipp/referer.xml
@@ -169,7 +169,14 @@
   </send>
   <recv response="200" />
 
-  <pause milliseconds="1000" />
+  <!--
+  This scenario is the 3pcc master so if it ends before the referee scenario,
+  the referee scenario will abort and the test will fail.  The two second pause
+  will allow the referee scenario to end first.  The the test case will kill this
+  scenario before the two seconds is up so no time is actually added to the overall
+  run time.
+  -->
+  <pause milliseconds="2000"/>
 
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>

--- a/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_bridge/different_stasis_app/sipp/referer.xml
+++ b/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_bridge/different_stasis_app/sipp/referer.xml
@@ -157,9 +157,14 @@
   </send>
   <recv response="200" />
 
-  <!-- Keep the call open for a while in case the 200 is lost to be     -->
-  <!-- able to retransmit it if we receive the BYE again.               -->
-  <pause milliseconds="500"/>
+  <!--
+  This scenario is the 3pcc master so if it ends before the referee scenario,
+  the referee scenario will abort and the test will fail.  The two second pause
+  will allow the referee scenario to end first.  The the test case will kill this
+  scenario before the two seconds is up so no time is actually added to the overall
+  run time.
+  -->
+  <pause milliseconds="2000"/>
 
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>

--- a/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_bridge/same_stasis_app/sipp/referer.xml
+++ b/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_bridge/same_stasis_app/sipp/referer.xml
@@ -157,9 +157,14 @@
   </send>
   <recv response="200" />
 
-  <!-- Keep the call open for a while in case the 200 is lost to be     -->
-  <!-- able to retransmit it if we receive the BYE again.               -->
-  <pause milliseconds="500"/>
+  <!--
+  This scenario is the 3pcc master so if it ends before the referee scenario,
+  the referee scenario will abort and the test will fail.  The two second pause
+  will allow the referee scenario to end first.  The the test case will kill this
+  scenario before the two seconds is up so no time is actually added to the overall
+  run time.
+  -->
+  <pause milliseconds="2000"/>
 
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>

--- a/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_bridge/same_stasis_app_accepted/sipp/referer.xml
+++ b/tests/rest_api/external_interaction/attended_transfer/stasis_bridge_to_stasis_bridge/same_stasis_app_accepted/sipp/referer.xml
@@ -158,9 +158,14 @@
   </send>
   <recv response="200" />
 
-  <!-- Keep the call open for a while in case the 200 is lost to be     -->
-  <!-- able to retransmit it if we receive the BYE again.               -->
-  <pause milliseconds="500"/>
+  <!--
+  This scenario is the 3pcc master so if it ends before the referee scenario,
+  the referee scenario will abort and the test will fail.  The two second pause
+  will allow the referee scenario to end first.  The the test case will kill this
+  scenario before the two seconds is up so no time is actually added to the overall
+  run time.
+  -->
+  <pause milliseconds="2000"/>
 
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>


### PR DESCRIPTION
In these tests, the referer scenarios are 3pcc masters and the referee scenarios
are 3pcc slaves.  If the master ends before the slave, the slave will fail
and cause the test to fail even though it actually passed.  Normally, Asterisk sends
a BYE to the referee first, then the master which is fine but occasionally, it sends
the BYE to the master first which causes the error.  Adding a delay to the end of
the referer script ensures that even if it receives the BYE first, it won't end before
the referee.  The test case kills the scenarios in the correct order so in practice,
the added delay doesn't actually add overall elapsed time to the test.
