### PR TITLE
mwi/unsolicited/incoming: Fix several issues causing instability.

### DIFF
--- a/tests/channels/pjsip/subscriptions/mwi/unsolicited/incoming/sipp/allowed.xml
+++ b/tests/channels/pjsip/subscriptions/mwi/unsolicited/incoming/sipp/allowed.xml
@@ -29,3 +29,5 @@ Voice-Message: 7/2 (3/6)
 	</send>
 
     <recv response="200" crlf="true"/>
+
+</scenario>

--- a/tests/channels/pjsip/subscriptions/mwi/unsolicited/incoming/sipp/not_allowed.xml
+++ b/tests/channels/pjsip/subscriptions/mwi/unsolicited/incoming/sipp/not_allowed.xml
@@ -29,3 +29,5 @@ Voice-Message: 7/2 (3/6)
 	</send>
 
     <recv response="404" crlf="true"/>
+
+</scenario>

--- a/tests/channels/pjsip/subscriptions/mwi/unsolicited/incoming/test-config.yaml
+++ b/tests/channels/pjsip/subscriptions/mwi/unsolicited/incoming/test-config.yaml
@@ -22,10 +22,14 @@ sipp-config:
     fail-on-any: True
     stop-after-scenarios: False
     test-iterations:
+#   Don't be tempted to run the sipp scenarios in parallel.  The test ends when the TestEvent
+#   for the "not allowed" scenario arrives so if Asterisk happens to send it before the
+#   TestEvent for the "allowed" scenario the test will end with an "Event occurred 0 times."
         -
             scenarios:
-#   Kick both sipp scenarios off at the same time since they're hitting different endpoints
                 - {'key-args': { 'scenario': 'allowed.xml', '-s': 'allowed', '-p': '5061' }}
+        -
+            scenarios:
                 - {'key-args': { 'scenario': 'not_allowed.xml', '-s': 'not_allowed', '-p': '5062' }}
 
 ami-action-config:


### PR DESCRIPTION
There are two sipp scenarios "allowed" and "not allowed", each generating a
TestEvent.  The test is set to end when the TestEvent for "not allowed"
arrives.  The scenarios were being run in parallel however so if the
"not allowed" scenario happens to finish first and generates its TestEvent,
the test will fail with an "Event occurred 0 times." error because the
"allowed" scenario hasn't had its chance yet.

* The sipp scenarios are now run seqauentially, "allowed" first, then
"not allowed".
* Both scenario files were missing the closing `</scenario>` tag for some
reason so that's been fixed.
