### PR TITLE
attended_transfer/caller_local_blond: Make more reliable

### DIFF
--- a/lib/python/asterisk/sipp.py
+++ b/lib/python/asterisk/sipp.py
@@ -143,9 +143,9 @@ class SIPpTestCase(TestCase):
         """
         super(SIPpTestCase, self).run()
 
-        for a in range(1, self.asterisk_instances):
-            self.ast[a-1].cli_exec('sip set debug on')
-            self.ast[a-1].cli_exec('pjsip set logger on')
+        for a in range(0, self.asterisk_instances):
+            self.ast[a].cli_exec('sip set debug on')
+            self.ast[a].cli_exec('pjsip set logger on')
 
         LOGGER.info("creating ami factory")
         if not isinstance(self.connect_ami, dict):
@@ -556,6 +556,9 @@ class SIPpProtocol(protocol.ProcessProtocol):
         # SIPp will send some 'normal' messages to stderr. Buffer them so we
         # can output them later if we want
         self.stderr.append(data)
+        LOGGER.debug("Received from SIPp scenario %s:\n %s" % (self._name,
+                        data.decode('utf-8', 'ignore')))
+        self.output += data.decode('utf-8', 'ignore')
 
     def processEnded(self, reason):
         """Override of ProcessProtocol.processEnded"""

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/configs/ast1/extensions.conf
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/configs/ast1/extensions.conf
@@ -1,9 +1,9 @@
 [default]
-exten => call_c,1,NoOp()
-	same => n,Dial(PJSIP/charlie)
+exten => bob,1,NoOp()
+	same => n,Dial(PJSIP/bob)
 	same => n,Hangup()
 
-exten => call_a,1,NoOp()
-        same => n,Dial(PJSIP/alice)
+exten => charlie,1,NoOp()
+        same => n,Dial(PJSIP/charlie)
         same => n,Hangup()
 

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/configs/ast1/pjsip.conf
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/configs/ast1/pjsip.conf
@@ -9,14 +9,9 @@ context=default
 disallow=all
 allow=ulaw
 direct_media=no
-aors=alice
 send_pai=yes
 send_rpid=yes
 callerid=Alice <alice>
-
-[alice]
-type=aor
-contact=sip:alice@127.0.0.1:5068
 
 [bob]
 type=endpoint
@@ -27,6 +22,11 @@ direct_media=no
 send_pai=yes
 send_rpid=yes
 callerid=Bob <bob>
+aors=bob
+
+[bob]
+type=aor
+contact=sip:bob@127.0.0.4:5060
 
 [charlie]
 type=endpoint
@@ -41,4 +41,4 @@ callerid=Charlie <charlie>
 
 [charlie]
 type=aor
-contact=sip:charlie@127.0.0.1:5067
+contact=sip:charlie@127.0.0.5:5060

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/sipp/alice_calls_bob.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/sipp/alice_calls_bob.xml
@@ -22,13 +22,13 @@
   <send retrans="500">
     <![CDATA[
 
-      INVITE sip:call_c@[remote_ip]:[remote_port] SIP/2.0
+      INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
       Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
-      From: <sip:bob@[local_ip]:[local_port]>;tag=[call_number]
-      To: <sip:transfer@[remote_ip]:[remote_port]>
+      From: <sip:alice@[local_ip]:[local_port]>;tag=[call_number]
+      To: <sip:bob@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: [cseq] INVITE
-      Contact: <sip:bob@[local_ip]:[local_port]>
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       Content-Length: [len]
@@ -54,30 +54,31 @@
   <send>
     <![CDATA[
 
-      ACK sip:call_c@[remote_ip]:[remote_port] SIP/2.0
+      ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
       Via: SIP/2.0/[transport] [local_ip]:[local_port];rport;branch=[branch]
       [last_From]
       [last_To]
       Call-ID: [call_id]
       CSeq: [cseq] ACK
-      Contact: sip:bob@[local_ip]:[local_port]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Content-Length: 0
 
     ]]>
   </send>
 
+  <pause milliseconds="1000"/>
   <!-- Put this leg on hold -->
   <send retrans="500">
     <![CDATA[
 
-      INVITE sip:call_c@[remote_ip]:[remote_port] SIP/2.0
+      INVITE sip:bob@[remote_ip]:[remote_port] SIP/2.0
       Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
       [last_From]
       [last_To]
       Call-ID: [call_id]
       CSeq: [cseq] INVITE
-      Contact: <sip:bob@[local_ip]:[local_port]>
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
       Content-Type: application/sdp
       Max-Forwards: 70
       Content-Length: [len]
@@ -103,13 +104,13 @@
   <send>
     <![CDATA[
 
-      ACK sip:call_c@[remote_ip]:[remote_port] SIP/2.0
+      ACK sip:bob@[remote_ip]:[remote_port] SIP/2.0
       Via: SIP/2.0/[transport] [local_ip]:[local_port];rport;branch=[branch]
       [last_From]
       [last_To]
       Call-ID: [call_id]
       CSeq: [cseq] ACK
-      Contact: sip:bob@[local_ip]:[local_port]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Content-Length: 0
 
@@ -152,54 +153,21 @@
   <send>
     <![CDATA[
 
-      REFER sip:call_c@[remote_ip]:[remote_port] SIP/2.0
+      REFER sip:bob@[remote_ip]:[remote_port] SIP/2.0
       Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
       [last_From:]
       [last_To]
       [last_Call-ID:]
       CSeq: [cseq] REFER
-      Contact: <sip:bob@[local_ip]:[local_port]>
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Refer-to: <[$remote_contact]?Replaces=REMOTE[$callid_chunk_1]%40[$callid_chunk_2]%3Bto-tag%3D[$remote_to_tag]%3Bfrom-tag%3D[$remote_from_tag]>
-      Referred-By: sip:bob@[local_ip]
+      Referred-By: sip:alice@[local_ip]
       Content-Length: 0
 
     ]]>
   </send>
   <recv response="202" rtd="true" crlf="true" />
-
-  <recv request="NOTIFY" />
-  <send>
-    <![CDATA[
-
-      SIP/2.0 200 OK
-      [last_Via:]
-      [last_From:]
-      [last_To]
-      [last_Call-ID:]
-      [last_CSeq:]
-      Contact: <sip:bob@[local_ip]:[local_port]>
-      Content-Length:0
-
-    ]]>
-  </send>
-
-  <recv request="NOTIFY" />
-
-  <send>
-    <![CDATA[
-
-      SIP/2.0 200 OK
-      [last_Via:]
-      [last_From:]
-      [last_To]
-      [last_Call-ID:]
-      [last_CSeq:]
-      Contact: <sip:bob@[local_ip]:[local_port]>
-      Content-Length:0
-
-    ]]>
-  </send>
 
   <!-- wait for referee scenario to finish then terminate this leg -->
   <recvCmd />

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/sipp/alice_calls_charlie.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/sipp/alice_calls_charlie.xml
@@ -32,13 +32,13 @@
   <send retrans="500">
     <![CDATA[
 
-      INVITE sip:call_a@[remote_ip]:[remote_port] SIP/2.0
+      INVITE sip:charlie@[remote_ip]:[remote_port] SIP/2.0
       Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
-      From: <sip:bob@[local_ip]:[local_port]>;tag=[call_number]
-      To: <sip:transfer@[remote_ip]:[remote_port]>
+      From: <sip:alice@[local_ip]:[local_port]>;tag=[call_number]
+      To: <sip:charlie@[remote_ip]:[remote_port]>
       Call-ID: [call_id]
       CSeq: [cseq] INVITE
-      Contact: <sip:bob@[local_ip]:[local_port]>
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Content-Type: application/sdp
       Content-Length: [len]
@@ -80,7 +80,7 @@
       Call-ID: [$original_callid]
       Remote-To-Tag: [$to_tag]
       Remote-From-Tag: [$from_tag]
-      Remote-URI: sip:call_a@[remote_ip]:[remote_port]
+      Remote-URI: sip:charlie@[remote_ip]:[remote_port]
     ]]>
   </sendCmd>
 
@@ -89,13 +89,13 @@
   <send>
     <![CDATA[
 
-      ACK sip:call_a@[remote_ip]:[remote_port] SIP/2.0
+      ACK sip:charlie@[remote_ip]:[remote_port] SIP/2.0
       Via: SIP/2.0/[transport] [local_ip]:[local_port];rport;branch=[branch]
       [last_From:]
       [last_To]
       Call-ID: [call_id]
       CSeq: [cseq] ACK
-      Contact: sip:bob@[local_ip]:[local_port]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
       Max-Forwards: 70
       Content-Length: 0
 

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/sipp/bob.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/sipp/bob.xml
@@ -52,8 +52,6 @@
     ]]>
   </send>
 
-  <pause milliseconds="5000"/>
-
   <send retrans="500">
     <![CDATA[
 
@@ -96,18 +94,6 @@
               search_in="hdr"
               check_it="true"
               assign_to="remote_party_id"/>
-          <!-- Save the From tag. We'll need it when we send our BYE -->
-          <ereg regexp="(;tag=.*)"
-              header="From:"
-              search_in="hdr"
-              check_it="true"
-              assign_to="remote_tag"/>
-          <!-- Save the From user portion of URI. We'll need it when we send our BYE -->
-          <ereg regexp="(sip:bob)"
-              header="From:"
-              search_in="hdr"
-              check_it="true"
-              assign_to="remote_user"/>
       </action>
   </recv>
 
@@ -138,25 +124,28 @@
   <recv request="ACK">
   </recv>
 
-  <send retrans="500">
+  <recv request="BYE">
+  </recv>
+
+  <send>
     <![CDATA[
 
-      BYE [$remote_user]@[remote_ip]:[remote_port] SIP/2.0
-      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
-      From: <sip:charlie@[local_ip]:[local_port]>;tag=[call_number]
-      To: <[$remote_user]@[remote_ip]:[remote_port]>[$remote_tag]
-      Call-ID: [call_id]
-      CSeq: [cseq] BYE
-      Contact: sip:charlie@[local_ip]:[local_port]
-      Max-Forwards: 70
-      Subject: Performance Test
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
       Content-Length: 0
 
     ]]>
   </send>
 
-  <recv response="200" crlf="true">
-  </recv>
+  <!-- Keep the call open for a while in case the 200 is lost to be     -->
+  <!-- able to retransmit it if we receive the BYE again.               -->
+  <pause milliseconds="1000"/>
+
 
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/sipp/charlie.xml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/sipp/charlie.xml
@@ -52,6 +52,8 @@
     ]]>
   </send>
 
+  <pause milliseconds="5000"/>
+
   <send retrans="500">
     <![CDATA[
 
@@ -84,16 +86,28 @@
 
   <recv request="INVITE">
       <action>
-          <ereg regexp="\"Alice\" &lt;sip:alice@127.0.0.1&gt;"
+          <ereg regexp="\"Bob\" &lt;sip:bob@127.0.0.1&gt;"
               header="P-Asserted-Identity"
               search_in="hdr"
               check_it="true"
               assign_to="asserted_identity"/>
-          <ereg regexp="\"Alice\" &lt;sip:alice@127.0.0.1&gt;"
+          <ereg regexp="\"Bob\" &lt;sip:bob@127.0.0.1&gt;"
               header="Remote-Party-ID"
               search_in="hdr"
               check_it="true"
               assign_to="remote_party_id"/>
+          <!-- Save the From tag. We'll need it when we send our BYE -->
+          <ereg regexp="(;tag=.*)"
+              header="From:"
+              search_in="hdr"
+              check_it="true"
+              assign_to="remote_tag"/>
+          <!-- Save the From user portion of URI. We'll need it when we send our BYE -->
+          <ereg regexp="(sip:alice)"
+              header="From:"
+              search_in="hdr"
+              check_it="true"
+              assign_to="remote_user"/>
       </action>
   </recv>
 
@@ -124,28 +138,25 @@
   <recv request="ACK">
   </recv>
 
-  <recv request="BYE">
-  </recv>
-
-  <send>
+  <send retrans="500">
     <![CDATA[
 
-      SIP/2.0 200 OK
-      [last_Via:]
-      [last_From:]
-      [last_To:]
-      [last_Call-ID:]
-      [last_CSeq:]
+      BYE [$remote_user]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: <sip:bob@[local_ip]:[local_port]>;tag=[call_number]
+      To: <[$remote_user]@[remote_ip]:[remote_port]>[$remote_tag]
+      Call-ID: [call_id]
+      CSeq: [cseq] BYE
       Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Max-Forwards: 70
+      Subject: Performance Test
       Content-Length: 0
 
     ]]>
   </send>
 
-  <!-- Keep the call open for a while in case the 200 is lost to be     -->
-  <!-- able to retransmit it if we receive the BYE again.               -->
-  <pause milliseconds="4000"/>
-
+  <recv response="200" crlf="true">
+  </recv>
 
   <!-- definition of the response time repartition table (unit is ms)   -->
   <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>

--- a/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/test-config.yaml
+++ b/tests/channels/pjsip/transfers/attended_transfer/nominal/caller_local_blonde/test-config.yaml
@@ -4,20 +4,43 @@ testinfo:
         "Originate two SIP calls through Asterisk to remote endpoints and then have
         one originating call transfer the other via REFER with Replaces header.
 
-        The four SIPp scenarios involved perform the following actions:
-        SIPp #1 (referer.xml) calls through Asterisk to SIPp #2 (uas.xml)
-        SIPp #1 kicks off SIPp #3 (referee.xml) which calls SIPp #4 (uas_hangup.xml).
-        SIPp #3 passes call information back to SIPp #1.
-        Before SIPp #4 answers SIPp #1 initiates an attended transfer via REFER with Replaces information from SIPp #3.
-        SIPp #3 is hung up.
-        SIPp #1 hangs up.
-        SIPp #4 continues to ring until it answers.
-        SIPp #2 receives a connected line update and the values are checked.
-        SIPp #4 answers.
-        SIPp #2 and SIPp #4 are bridged.
-        SIPp #4 receives a connected line update and the values are checked.
-        SIPp #4 hangs up.
-        SIPp #2 is hung up."
+        High-level scenario:
+        Alice calls Bob.  When he answers, Alice puts him on hold.
+        Alice calls Charlie.  Before he answers, Alice does a REFER Bob->Charlie.
+        When Charlie answers he and Bob are bridged and Alice goes away.
+
+        NOTE:  sipp doesn't allow more than one dialog in a scenario file so Alice
+        is actually implemented in two scenario files: alice_calls_bob and alice_calls_charlie.
+        The two coordinate using sipp's 3pcc capability.
+
+        Low-level flow:
+        alice_calls_bob starts by calling bob.
+        bob answers.
+        alice_calls_bob waits for a second then sends a reINVITE to put bob on hold.
+        alice_calls_bob does a sendCmd to start alice_calls_charlie then waits on a recvCmd from alice_calls_charlie.
+        charlie waits 5 seconds before answering.
+        alice_calls_charlie waits 1 second then does a sendCmd back to alice_calls_bob.
+        charlie is still waiting.
+        alice_calls_bob recvCmd returns.
+        alice_calls_bob does a REFER bob->charlie.
+        alice_calls_bob receives a 202 and 2 NOTIFYs.  The NOTIFYs are handled automatically by sipp.
+        alice_calls_bob waits again on a recvCmd from alice_calls_charlie.
+        alice_calls_charlie gets a 603 and sends an ACK.
+        alice_calls_charlie does a sendCmd to alice_calls_bob.
+        alice_calls_charlie.xml ENDS.
+        alice_calls_bob.xml recvCmd returns.
+        alice_calls_bob.xml sends a BYE.
+        alice_calls_bob.xml receives a 481.
+        alice_calls_bob.xml ENDS.
+        charlie finally answers.
+        charlie gets an ACK followed by a reINVITE with Bob's callerID.
+        charlie sends a 200 and gets an ACK.
+        bob gets a reINVITE with Charlie's callerID.
+        bob sends a 200 and gets an ACK.
+        bob waits on a BYE.
+        charlie sends a BYE.
+        bob gets the BYE and ENDS.
+        charlie ENDS.
 
 test-modules:
     add-test-to-search-path: True
@@ -34,10 +57,14 @@ test-object-config:
     test-iterations:
         -
             scenarios:
-                - { 'key-args': {'scenario':'uas.xml', '-p':'5067', '-m':'2', '-sleep': '2'} }
-                - { 'key-args': {'scenario':'uas_hangup.xml', '-p':'5068', '-m':'2', '-sleep': '2'} }
-                - { 'coordinated-sender': {'key-args': {'scenario':'referer.xml', '-p':'5066', '-sleep': '2'} },
-                    'coordinated-receiver': {'key-args': {'scenario':'referee.xml', '-p':'5065'} } }
+                - { 'coordinated-sender': {'key-args': {'scenario':'alice_calls_bob.xml', '-i':'127.0.0.2', '-p':'5060', '-sleep': '2'},
+                                           'ordered-args': [ '-aa', '-bind_local' ] },
+                    'coordinated-receiver': {'key-args': {'scenario':'alice_calls_charlie.xml', '-i':'127.0.0.3', '-p':'5060'},
+                                             'ordered-args': [ '-bind_local' ] } }
+                - { 'key-args': {'scenario':'bob.xml', '-i':'127.0.0.4', '-p':'5060', '-m':'2', '-sleep': '2'},
+                    'ordered-args': [ '-bind_local' ] }
+                - { 'key-args': {'scenario':'charlie.xml', '-i':'127.0.0.5', '-p':'5060', '-m':'2', '-sleep': '2'},
+                    'ordered-args': [ '-bind_local' ] }
 
 ami-config:
     -


### PR DESCRIPTION
* Trying to figure out how the test actually works took most of the time.
To make it easier to understand, instead of using names like referer, referee,
etc. the scenarios are now named after our usual actors: alice, bob and charlie.
* Numerous naming clarifications were made to the scenario files.
* The test description has been re-written to include both a high-level and
low-level flow.
* Instead of having the 4 sipp scenarios all bind to 127.0.0.1 with different
ports, they bind to 127.0.0.2, 3, 4, 5 port 5060.
* The usual test failure was in the alice_calls_bob scenario when it's supposed
to receive 2 sipfrag NOTIFYs.  For some reason, sipp would occasionally just
end the scenario after the first NOTIFY with no indication as to why.  To get
around this, alice_calls_bob.xml no longer explicitly deals with the NOTIFYs
and instead lets sipp deal with them by virtue of the `-aa` option.
* Also fixed an issue in sipp.py that prevented SIP packets from being output
to the Asterisk logs when there was only 1 asterisk instance.
