### PR TITLE
apps/directory/directory_result: Move from users.conf to voicemail.conf.

### DIFF
--- a/tests/apps/directory/directory_result/configs/ast1/users.conf
+++ b/tests/apps/directory/directory_result/configs/ast1/users.conf
@@ -1,5 +1,0 @@
-[2020]
-fullname=Dog Dog
-description=easy test DTMF string with no overlaps - 364
-userbase=2020
-hasdirectory=true

--- a/tests/apps/directory/directory_result/configs/ast1/voicemail.conf
+++ b/tests/apps/directory/directory_result/configs/ast1/voicemail.conf
@@ -1,0 +1,20 @@
+; Voicemail Configuration
+
+[general]
+format = ulaw|wav49|wav
+skipms = 3000
+maxsilence = 0
+silencethreshold = 128
+maxlogins = 3
+minsecs = 0
+
+[zonemessages]
+eastern = America/New_York|'vm-received' Q 'digits/at' IMp
+central = America/Chicago|'vm-received' Q 'digits/at' IMp
+central24 = America/Chicago|'vm-received' q 'digits/at' H N 'hours'
+military = Zulu|'vm-received' q 'digits/at' H N 'hours' 'phonetic/z_p'
+european = Europe/Copenhagen|'vm-received' a d b 'digits/at' HM
+
+[default]
+2020 => 1234,Ralph Dog
+


### PR DESCRIPTION
This test was still using users.conf (which has been gone for a while)
to create the directory making it fail every time.  Changed over to use
voicemail.conf.
